### PR TITLE
updated "Accessing External Build process' logs" section

### DIFF
--- a/reference_guide/frameworks_and_external_apis/external_builder_api.md
+++ b/reference_guide/frameworks_and_external_apis/external_builder_api.md
@@ -93,9 +93,11 @@ The log file is located under the directory
 <ide-system-directory>/log/build-log
 ```
 
-There both `build-log.log` and `build-log.xml` files can be found.
-The `build-log.xml` is a log4j configuration file, where the log level and desired logging categories can be adjusted.
+There both `build-log.log` and `build-log.properties` files can be found.
+The `build-log.properties` is a log4j configuration file, where the log level and desired logging categories can be adjusted. 
 This file contains logging from all  build sessions, including those from the auto-make.
+
+In IntelliJ IDEA versions before version 14.1 log4j configuration was stored in `build-log.xml`.
 
 ### Accessing project model and configuration from External Build
 


### PR DESCRIPTION
Since IDEA 14.1 logging is configured via properties file, not xml file.