### PR TITLE
change FindUsages getWordScanner not use a static instance.

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleFindUsagesProvider.java
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleFindUsagesProvider.java
@@ -12,14 +12,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class SimpleFindUsagesProvider implements FindUsagesProvider {
-    private static final DefaultWordsScanner WORDS_SCANNER =
-            new DefaultWordsScanner(new SimpleLexerAdapter(),
-                    TokenSet.create(SimpleTypes.KEY), TokenSet.create(SimpleTypes.COMMENT), TokenSet.EMPTY);
-
     @Nullable
     @Override
     public WordsScanner getWordsScanner() {
-        return WORDS_SCANNER;
+        return new DefaultWordsScanner(new SimpleLexerAdapter(),
+                    TokenSet.create(SimpleTypes.KEY), TokenSet.create(SimpleTypes.COMMENT), TokenSet.EMPTY);;
     }
 
     @Override


### PR DESCRIPTION
If it is static then there are multi-threading issues. When indexing multiple threads are running and overwriting the lexer state that the word scanner uses.

I copied the SimplePlugin find usages class and spent hours chasing index out range bugs. I also noticed that the SimplePlugin which I have installed in my plugin dev environment would once in a while cause an exception but I did not pay it much attention. The static word scanner is the source.