### PR TITLE
Explicitly depend on SimpleLanguage.INSTANCE

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleParserDefinition.java
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleParserDefinition.java
@@ -13,8 +13,7 @@ public class SimpleParserDefinition implements ParserDefinition {
   public static final TokenSet WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
   public static final TokenSet COMMENTS = TokenSet.create(SimpleTypes.COMMENT);
 
-  public static final IFileElementType FILE =
-      new IFileElementType(Language.<SimpleLanguage>findInstance(SimpleLanguage.class));
+  public static final IFileElementType FILE = new IFileElementType(SimpleLanguage.INSTANCE);
 
   @NotNull
   @Override


### PR DESCRIPTION
The use of `Language.findInstance()` implicitly depended on the fact that `SimpleLanguage.INSTANCE` was referenced at some earlier point in time. In this case, that happens because the instantiation of `SimpleParserDefinition` triggers the instantiation of `COMMENTS`, which relies on `SimpleTypes.COMMENT`.

When basing one's work on this sample project, however, one may run into issues. Specifically, the absence of a custom comment token type will mean a failure to correctly instantiate the singleton language object. Making the dependence on `SimpleLanguage.INSTANCE` explicit prevents that issue from occurring.