### PR TITLE
Fix broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Follow these steps to work with Docker:
     >
     > In order to hit the container's port 4000 from Windows or the Mac, it is necessary to hit the IP address of the docker client (virtual machine). Use `docker-machine ip default` to get the IP address of the docker client. Use `X.X.X.X:4000` to hit the client in the virtual machine, which is in turn mapped to the container's port 4000.
     >
-    > Alternatively, modify the virtual machine's settings to automatically forward port 4000 to `localhost`. See this [blog post](http://acaird.github.io/computers/2014/11/16/docker-virtualbox-host-networking/) for more details.
+    > Alternatively, modify the virtual machine's settings to automatically forward port 4000 to `localhost`. See this [blog post](http://acaird.github.io/computers/2014/11/16/docker-virtualbox-host-networking) for more details.
  
     * Mount the current directory (`$PWD` is a Unix style environment variable. You can use `%CD%` on Windows, or specify the full path) as `/usr/src/app` inside the docker container. This means the docker image will see the `intellij-sdk-docs` repo as the folder `/usr/src/app`.
 

--- a/basics/architectural_overview.md
+++ b/basics/architectural_overview.md
@@ -4,8 +4,6 @@ title: Architectural Overview
 
 This topic describes the architecture of the *IntelliJ Platform* from a plugin developer's point of view. It is organized in a task-based manner to answer specific questions like "what can I do with this object?", "how do I get to this object?" and so on.
 
-Before proceeding please make sure you're familiar with the basic concepts of IntelliJ Platform plugin development. If not, consider starting with the live demo and tutorials at [www.jetbrains.com/idea/plugins/](http://www.jetbrains.com/idea/plugins/) and then returning to this document.
-
 The following subjects are covered:
 
 * [General threading rules](architectural_overview/general_threading_rules.md)

--- a/basics/checkout_and_build_community.md
+++ b/basics/checkout_and_build_community.md
@@ -56,7 +56,6 @@ The source code of stable releases of IntelliJ IDEA Community Edition is also av
 - [IntelliJ IDEA Community Edition 13.0.5](https://download.jetbrains.com/idea/ideaIC-13.0.5-src.tar.bz2)
 - [IntelliJ IDEA Community Edition 12.1.8](https://download.jetbrains.com/idea/ideaIC-12.1.8-src.tar.bz2)
 - [IntelliJ IDEA Community Edition 12.0.4](https://download.jetbrains.com/idea/ideaIC-12.0.4-src.tar.bz2)
-- [IntelliJ IDEA Community Edition 11.1.4](https://download.jetbrains.com/idea/ideaIC-11.1.4-src.tar.bz2)
 - [IntelliJ IDEA Community Edition 11.0.2](https://download.jetbrains.com/idea/ideaIC-11.0.2-src.tar.bz2)
 - [IntelliJ IDEA Community Edition 10.5.4](https://download.jetbrains.com/idea/ideaIC-10.5.4-src.tar.bz2)
 - [IntelliJ IDEA Community Edition 10.0.3](https://download.jetbrains.com/idea/ideaIC-10.0.3-src.tar.bz2)

--- a/basics/getting_started/publishing_plugin.md
+++ b/basics/getting_started/publishing_plugin.md
@@ -11,6 +11,6 @@ When your plugin is ready, you can upload it to the [IntelliJ Plugin Repository]
 
 **To upload your plugin to Intellij Plugin Repository**
 
-1. [Login to IntelliJ Plugin Repository](https://plugins.jetbrains.com/space) with your personal JetBrains account.
+1. [Login to IntelliJ Plugin Repository](https://plugins.jetbrains.com/author/me) with your personal JetBrains account.
 2. On your Profile page that opens, click **Add new plugin**.
 3. Fill in the **Add new plugin** form that opens and click the **Add the plugin** button to upload your plugin.

--- a/basics/project_structure.md
+++ b/basics/project_structure.md
@@ -8,7 +8,7 @@ This topic considers the concept of projects based on *IntelliJ Platform* and re
 
 ## Project and its components
 
-This section briefly discusses the IDEA project structure, project components and related terms.  For more information about projects and their components, refer to [Project](http://www.jetbrains.com/idea/help/project.html), [Module](http://www.jetbrains.com/idea/help/module.html), [Library](http://www.jetbrains.com/idea/help/library.html), [Facet](http://www.jetbrains.com/idea/help/facet.html) in the *IntelliJ IDEA* Web Help.
+This section briefly discusses the IDEA project structure, project components and related terms.  For more information about projects and their components, refer to [Project](https://www.jetbrains.com/help/idea/about-projects.html), [Module](https://www.jetbrains.com/help/idea/about-modules.html), [Library](https://www.jetbrains.com/help/idea/working-with-libraries.html), [Facet](https://www.jetbrains.com/help/idea/adding-support-for-frameworks-and-technologies.html#facets) in the *IntelliJ IDEA* Web Help.
 
 ### Project
 
@@ -26,7 +26,7 @@ A _library_ is an archive of compiled code (such as JAR files) that your modules
 * **Project Library**: the library classes are visible within the project and the library information is recorded in the project `.ipr` file or in `.idea/libraries`.
 * **Global Library**: the library information is recorded in the `applicationLibraries.xml` file into the `~/.IntelliJIdea/config/options` directory. Global libraries are similar to project libraries, but are visible for the different projects.
 
-For more information about libraries, refer to [Library](http://www.jetbrains.com/idea/help/library.html).
+For more information about libraries, refer to [Library](https://www.jetbrains.com/help/idea/working-with-libraries.html).
 
 ### SDK
 
@@ -36,13 +36,13 @@ The SDK determines which API library is used to build the project. If your proje
 
 Optionally, you can configure individual SDK for each module.
 
-For more information about SDKs, see [Configuring Global, Project and Module SDKs](https://www.jetbrains.com/idea/help/configuring-global-project-and-module-sdks.html) in the *IntelliJ IDEA* Web Help.
+For more information about SDKs, see [Working with SDKs](https://www.jetbrains.com/help/idea/working-with-sdks.html) in the *IntelliJ IDEA* Web Help.
 
 ### Facet
 
 A _facet_ represents certain configuration, specific for a particular framework/technology, associated with a module. A module can have multiple facets. E.g. Spring specific configuration is stored in a Spring facet.
 
-For more information about facets see [Facet](http://www.jetbrains.com/idea/help/facet.html) and [Facet Dependencies](http://www.jetbrains.com/idea/help/available-facets-and-their-dependencies.html) in the *IntelliJ IDEA* Web Help.
+For more information about facets see [Facet](https://www.jetbrains.com/help/idea/adding-support-for-frameworks-and-technologies.html#facets) and [Language and Framework Specific Guidelines](https://www.jetbrains.com/help/idea/language-and-framework-specific-guidelines.html) in the *IntelliJ IDEA* Web Help.
 
 ## Project Structure
 
@@ -61,7 +61,7 @@ The Java classes and interfaces that you can use to explore and change the proje
 
 ### How to Work with Project Files?
 
-The *IntelliJ Platform* stores the project configuration data in XML files. The list of those files depends on the plugin [project format](http://www.jetbrains.com/idea/help/project.html).
+The *IntelliJ Platform* stores the project configuration data in XML files. The list of those files depends on the plugin [project format](https://www.jetbrains.com/help/idea/about-projects.html).
 
 For _file-based_ format projects, the information core to the project itself (e.g. location of the component modules, compiler settings, etc.) is stored in the `%project_name%.ipr` file.
 

--- a/phpstorm/existing_plugins.md
+++ b/phpstorm/existing_plugins.md
@@ -20,7 +20,7 @@ Features include: Goto for factories and template paths, autocomplete for factor
 
 * [Official Magicento Web Site](http://magicento.com/)
 * [GitHub](https://github.com/enriquepiatti/Magicento)
-* [Magicento in PhpStorm Plugins Repository](http://plugins.jetbrains.com/plugin/?webide&pluginId=7089)
+* [Magicento in PhpStorm Plugins Repository](https://plugins.jetbrains.com/plugin/7089-magicento)
 
 ## YiiStorm
 
@@ -29,11 +29,5 @@ Features are: Going from render and renderPartial to the view file. Includes con
 
 * [Official YiiStorm Web Site](http://mazx.ru/)
 * [GitHub](https://github.com/cmazx/yiistorm)
-* [YiiStorm in PhpStorm Plugins Repository](https://plugins.jetbrains.com/plugin/?webide&pluginId=7182)
+* [YiiStorm in PhpStorm Plugins Repository](https://plugins.jetbrains.com/plugin/7182-yiistorm)
 
-## Symfony2 - Clickable Views
-
-Symfony2 - Clickable Views is a plugin for Symfony2 Framework developers. Resolves on Ctrl+Click the corresponding twig template in your Symfony2 project. This plugin demands a projectstructure which you can find in the Symfony2 Std. Edition and will not work with custom layouts.
-
-* [GitHub](https://github.com/xenji/phpstorm-symfony2-plugin)
-* [Symfony2 - Clickable Views plugin in PhpStorm Plugins Repository](https://plugins.jetbrains.com/plugin?pr=webide&pluginId=7057)

--- a/phpstorm/phpstorm.md
+++ b/phpstorm/phpstorm.md
@@ -2,7 +2,7 @@
 title: PhpStorm Plugin Development
 ---
 
-Plugins for PhpStorm are developed in Java using IntelliJ IDEA (Community Edition is sufficient in this case). You will also need a copy of PhpStorm to develop against. The [PsiViewer plugin](https://plugins.jetbrains.com/plugin/?pluginId=227) will also be useful.
+Plugins for PhpStorm are developed in Java using IntelliJ IDEA (Community Edition is sufficient in this case). You will also need a copy of PhpStorm to develop against. The [PsiViewer plugin](https://plugins.jetbrains.com/plugin/227-psiviewer) will also be useful.
 
 ### PhpStorm Specifics
 

--- a/reference_guide/custom_language_support/implementing_lexer.md
+++ b/reference_guide/custom_language_support/implementing_lexer.md
@@ -56,10 +56,10 @@ and not as an array of characters.
 
 
 For developing lexers using JFlex, the
-[JFlex Support](https://plugins.jetbrains.com/plugin/?id=263)
+[JFlex Support](https://plugins.jetbrains.com/plugin/263-jflex-support)
 plugin can be useful.
 It provides syntax highlighting and other useful features for editing JFlex files.
-[GrammarKit plugin](https://plugins.jetbrains.com/plugin/?id=6606)
+[GrammarKit plugin](https://plugins.jetbrains.com/plugin/6606-grammar-kit)
 also has builtin JFlex support.
 
 **Note:**

--- a/reference_guide/custom_language_support/implementing_parser_and_psi.md
+++ b/reference_guide/custom_language_support/implementing_parser_and_psi.md
@@ -53,7 +53,7 @@ There is currently no ready way to reuse existing language grammars, for example
 The parsers need to be coded manually.
 
 Custom language parser and PSI classes can be generated from grammars using
-[Grammar-Kit](https://plugins.jetbrains.com/plugin/?id=6606) plugin.
+[Grammar-Kit](https://plugins.jetbrains.com/plugin/6606-grammar-kit) plugin.
 Besides code generation it provides various features for editing grammar files: syntax highlighting, quick navigation, refactorings and more.
 The Grammar-Kit plugin is built using its own engine and its source code can be found on
 [GitHub](https://github.com/JetBrains/Grammar-Kit).
@@ -125,7 +125,7 @@ and
 classes.
 
 A very helpful tool for debugging the PSI implementation is the
-[PsiViewer plugin](https://plugins.jetbrains.com/plugin/?id=227).
+[PsiViewer plugin](https://plugins.jetbrains.com/plugin/227-psiviewer).
 It can show you the structure of the PSI built by your plugin, the properties of every PSI element and highlight its text range.
 
 Please see

--- a/reference_guide/project_model.md
+++ b/reference_guide/project_model.md
@@ -4,7 +4,7 @@ title: Project Model. Roots and Libraries. Configuring Project from Code.
 
 This section considers the internal architecture of *IntelliJ Platform* projects and gives an overview for classes and packages of the API used to manipulate with projects and their components, such as modules, facets, libraries, SDK.
 
-For general information about the concept of a projects and concepts related to it, refer to [Project](http://www.jetbrains.com/idea/help/project.html), [Module](http://www.jetbrains.com/idea/help/module.html), [Library](http://www.jetbrains.com/idea/help/library.html), and [Facet](http://www.jetbrains.com/idea/help/facet.html) in the [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/intellij-idea.html).
+For general information about the concept of a projects and concepts related to it, refer to [Project](https://www.jetbrains.com/help/idea/about-projects.html), [Module](https://www.jetbrains.com/help/idea/about-modules.html), [Library](https://www.jetbrains.com/help/idea/working-with-libraries.html), and [Facet](https://www.jetbrains.com/help/idea/adding-support-for-frameworks-and-technologies.html#facets) in the [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/intellij-idea.html).
 
 ## Project Structure
 

--- a/reference_guide/project_model/library.md
+++ b/reference_guide/project_model/library.md
@@ -10,7 +10,7 @@ The IntelliJ Platform supports three types of libraries:
 * **Global Library**: the library information is recorded in the applicationLibraries.xml file into the `<User Home>/.IntelliJIdea/config/options` directory. Global libraries are similar to project libraries, but are visible for the different projects.
 
 For more information about libraries, refer to
-[Library](http://www.jetbrains.com/idea/help/library.html).
+[Library](https://www.jetbrains.com/help/idea/working-with-libraries.html).
 
 ## Accessing Libraries and Jars
 

--- a/reference_guide/project_model/project.md
+++ b/reference_guide/project_model/project.md
@@ -6,7 +6,7 @@ In the *IntelliJ Platform*, a project encapsulates all your source code, librari
 
 ## Working with projects
 
-The *IntelliJ Platform* stores the project configuration data in XML files. The list of those files depends on the plugin [project](http://www.jetbrains.com/idea/help/project.html) format.
+The *IntelliJ Platform* stores the project configuration data in XML files. The list of those files depends on the plugin [project](https://www.jetbrains.com/help/idea/about-projects.html) format.
 
 For file based format projects, the information core to the project itself (e.g. location of the component modules, compiler settings, etc.) is stored in the `%project_name%.ipr` file. The information about modules the project includes is stored in `%module_name%.iml` files. Module files are created for each module.
 

--- a/reference_guide/project_model/sdk.md
+++ b/reference_guide/project_model/sdk.md
@@ -2,7 +2,7 @@
 title: SDK
 ---
 
-Every project uses a Software Development Kit (SDK). For Java projects, the SDK is referred to as the JDK (Java Development Kit). The SDK determines which API library is used to build the project. If your project is multi-module, the project SDK by default is common for all modules within the project. Optionally, you can configure individual SDKs for each module. For more information about SDKs, see [SDK](https://www.jetbrains.com/idea/help/sdk.html) and [Configuring Global, Project and Module SDKs](https://www.jetbrains.com/idea/help/configuring-global-project-and-module-sdks.html) in the IntelliJ IDEA Web Help.
+Every project uses a Software Development Kit (SDK). For Java projects, the SDK is referred to as the JDK (Java Development Kit). The SDK determines which API library is used to build the project. If your project is multi-module, the project SDK by default is common for all modules within the project. Optionally, you can configure individual SDKs for each module. For more information about SDKs, see [SDK](https://www.jetbrains.com/help/idea/working-with-sdks.html) in the IntelliJ IDEA Web Help.
 
 ## Getting project SDK information
 

--- a/tutorials/build_system/deployment.md
+++ b/tutorials/build_system/deployment.md
@@ -74,7 +74,7 @@ For best results, plugin developers should build against a fixed version, rather
 
 ### 2.3 Deploy your plugin
 
-The first step when deploying a plugin is to confirm that it works correctly. You may wish to verify this by [installing your plugin from disk](https://www.jetbrains.com/idea/help/installing-plugin-from-disk.html) on a fresh instance of IntelliJ IDEA Community Edition. Once you are confident the plugin works as intended, make sure the plugin version is updated, as the JetBrains Plugin repository will not accept multiple artifacts with the same version. To deploy a new version of your plugin to the JetBrains plugin repository, execute the following Gradle command:
+The first step when deploying a plugin is to confirm that it works correctly. You may wish to verify this by [installing your plugin from disk](https://www.jetbrains.com/help/idea/installing-a-plugin-from-the-disk.html) on a fresh instance of IntelliJ IDEA Community Edition. Once you are confident the plugin works as intended, make sure the plugin version is updated, as the JetBrains Plugin repository will not accept multiple artifacts with the same version. To deploy a new version of your plugin to the JetBrains plugin repository, execute the following Gradle command:
 
 ```bash
 gradle publishPlugin

--- a/tutorials/code_inspections.md
+++ b/tutorials/code_inspections.md
@@ -28,7 +28,7 @@ The **comparingReferences** sample plugin is available in the `<%IntelliJ SDK 
 **To run the sample plugin**
 
 1. Start **IntelliJ IDEA** and open the **comparingReferences** plugin project saved into the `<%IntelliJ SDK Docs project%>/code_samples/comparing_references_inspection` directory.
-2. Open the [Project Structure](http://www.jetbrains.com/idea/webhelp/project-structure.html) dialog and ensure that the project settings are valid for your environment.
+2. Open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog and ensure that the project settings are valid for your environment.
 3. If necessary, modify the [Run/Debug Configurations](http://www.jetbrains.com/idea/webhelp/run-debug-configuration-plugin.html) and Run the plugin by choosing the **Run | Run** on the main menu.
 
 #### Configuring the Plugin
@@ -69,4 +69,4 @@ return (s1.equals(s2));
 
 The sample plugin contains the `TestThisPlugin` Java class in the `testSource/testPlugin` package and the test data in the `testData` directory. This test adds two test cases to this plugin project. To run test cases, run the `YourTest.test()` or `YourTest.test1()` method, respectively.
 
-For detailed information about testing and all related procedures, refer to [Testing](http://www.jetbrains.com/idea/webhelp/testing.html) and [Testing Support](http://www.jetbrains.com/idea/webhelp/testing-support.html) in the **IntelliJ IDEA** Web Help.
+For detailed information about testing and all related procedures, refer to [Testing](http://www.jetbrains.com/idea/webhelp/testing.html) in the **IntelliJ IDEA** Web Help.

--- a/tutorials/code_intentions.md
+++ b/tutorials/code_intentions.md
@@ -37,7 +37,7 @@ The **ConditionalOperatorConverter** sample plugin is available in the `<%Inte
 **To run the sample plugin**
 
 1. Start **IntelliJ IDEA** and open the **conditionalOperatorConvertor** plugin project saved into the `<%IntelliJ SDK Docs project%>/code_samples/conditional_operator_intention` directory.
-2. Open the [Project Structure](http://www.jetbrains.com/idea/webhelp/project-structure.html) dialog and ensure that the project settings are valid for your environment.
+2. Open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog and ensure that the project settings are valid for your environment.
 3. If necessary, modify the [Run/Debug Configurations](http://www.jetbrains.com/idea/webhelp/run-debug-configuration-plugin.html) and Run the plugin by choosing the **Run** on the main menu.
 
 #### How does it work?
@@ -66,4 +66,4 @@ if ((n>=0)) {
 
 The sample plugin contains the `YourTest` Java class in the `testSource/testPlugin/` package and the test data in the `testData/` directory. To perform the plugin test, run the `YourTest.test()` method.
 
-For detailed information about testing and all related procedures, refer to [Testing](http://www.jetbrains.com/idea/webhelp/testing.html) and [Testing Support](http://www.jetbrains.com/idea/webhelp/testing-support.html) in the **IntelliJ IDEA** Web Help.
+For detailed information about testing and all related procedures, refer to [Testing](http://www.jetbrains.com/idea/webhelp/testing.html) in the **IntelliJ IDEA** Web Help.

--- a/tutorials/custom_language_support/prerequisites.md
+++ b/tutorials/custom_language_support/prerequisites.md
@@ -17,9 +17,9 @@ git clone git://git.jetbrains.org/idea/community.git idea
 
 Make sure that the bundled Plugin DevKit plugin is enabled.
 Install and enable
-[Grammar-Kit](http://plugins.intellij.net/plugin?pluginId=6606)
+[Grammar-Kit](https://plugins.jetbrains.com/plugin/6606-grammar-kit)
 and
-[PsiViewer](http://plugins.intellij.net/plugin/?pluginId=227)
+[PsiViewer](https://plugins.jetbrains.com/plugin/227-psiviewer)
 plugins.
 
 ### 1.4. Configure SDK and source files

--- a/user_interface_components/tool_windows.md
+++ b/user_interface_components/tool_windows.md
@@ -100,7 +100,7 @@ To clarify how to develop plugins that create tool windows, consider the **tool
 
 1. Start **IntelliJ IDEA** and open the **tool_window** project saved into the [code_samples/tool_window](https://github.com/JetBrains/intellij-sdk-docs/tree/master/code_samples/tool_window) directory.
 2. Ensure that the project settings are valid for your environment. If necessary, modify the project settings.  
-To view or modify the project settings, you can open the [Project Structure](https://www.jetbrains.com/idea/help/configuring-project-structure.html).
+To view or modify the project settings, you can open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog.
 3. Run the plugin by choosing the **Run | Run** on the main menu.  
 If necessary, change the [Run/Debug Configurations](http://www.jetbrains.com/idea/help/run-debug-configuration-plugin.html).
 


### PR DESCRIPTION
This PR fixes a number of broken links, or fixes links that fail to redirect correctly with the link-checker. Once this PR is merged, we can enable the link checker as part of the build, and any broken external links (not internal!) will break the build.

Most links have been easy to fix. Most are links to the main IntelliJ help on projects, modules, facets and SDKs. I've pointed them where I think they should go, but would appreciate a review that this is correct.