### PR TITLE
Clarify the role of PsiNamedElement with respect to PsiReference

### DIFF
--- a/reference_guide/custom_language_support/references_and_resolve.md
+++ b/reference_guide/custom_language_support/references_and_resolve.md
@@ -21,9 +21,14 @@ and return the references as an array.
 
 The main method of the
 [PsiReference](upsource:///platform/core-api/src/com/intellij/psi/PsiReference.java)
-interface is `resolve()`, which returns the element to which the reference points, or `null` if it was not possible to resolve the reference to a valid element (for example, should it point to an undefined class).
-A counterpart to this method is `isReferenceTo()`, which checks if the reference resolves to the specified element.
-The latter method can be implemented by calling `resolve()` and comparing the result with the passed PSI element, but additional optimizations are possible (for example, performing the tree walk only if the element text is equal to the text of the reference).
+interface is `resolve()`, which returns the element to which the reference points, or `null` if it was not possible to resolve the reference to a valid element (for example, should it point to an undefined class). The resolved element should implement the [PsiNamedElement](upsource:///platform/core-api/src/com/intellij/psi/PsiNamedElement.java) interface.
+
+> **NOTE** While both the referencing element and the referenced element both have a name, only the element which **introduces** the name (e.g. the definition `int x = 42`) needs to implement the [PsiNamedElement](upsource:///platform/core-api/src/com/intellij/psi/PsiNamedElement.java) interface. It is not necessary for the referencing element at the point of usage (e.g. the `x` in the expression `x + 1`) to implement [PsiNamedElement](upsource:///platform/core-api/src/com/intellij/psi/PsiNamedElement.java).
+
+> **TIP** In order to enable more advanced IntelliJ functionality, prefer implementing [PsiNameIdentifierOwner](upsource:///platform/core-api/src/com/intellij/psi/PsiNameIdentifierOwner.java) over [PsiNamedElement](upsource:///platform/core-api/src/com/intellij/psi/PsiNamedElement.java) where possible.
+
+A counterpart to the `resolve()` method is `isReferenceTo()`, which checks if the reference resolves to the specified element. The latter method can be implemented by calling `resolve()` and comparing the result with the passed PSI element, but additional optimizations are possible (for example, performing the tree walk only if the element text is equal to the text of the reference).
+
 
 **Example**:
 [Reference](upsource:///plugins/properties/src/com/intellij/lang/properties/ResourceBundleReference.java)


### PR DESCRIPTION
The creator of the Elm plugin for IntelliJ was confused by how `PsiNamedElement` works for referenced and referencing elements, which prevented "Find Usages" from working as expected. He [asked for help](https://github.com/durkiewicz/elm-plugin/issues/22#issuecomment-318663125), and I found the root cause to be improper usage of `PsiNamedElement`.

I also found a [few](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206146809-Language-API-1-getVariants-never-called-2-Find-Usages-only-partly-works) [other](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206121149-How-to-enable-refactoring-of-definitions-in-custom-XML-language-like-Ant-target-property-) [people](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206103209-PsiNamedElement-vs-PsiNameIdentifierOwner) who were similarly confused on the message board, so I wanted to attempt to fix the documentation.