### PR TITLE
Removes vendor logo

### DIFF
--- a/basics/plugin_structure/plugin_configuration_file.md
+++ b/basics/plugin_structure/plugin_configuration_file.md
@@ -29,10 +29,8 @@ The following is a sample plugin configuration file. This sample showcases and d
 
   <!-- The vendor of the plugin.
        The optional "url" attribute specifies the URL of the vendor homepage.
-       The optional "email" attribute specifies the e-mail address of the vendor.
-       The optional "logo" attribute specifies the path within the plugin JAR
-       to a 16x16 icon to be displayed next to the plugin name in the welcome screen.   -->
-  <vendor url="http://www.jetbrains.com" email="support@jetbrains.com" logo="icons/plugin.png">Foo Inc.</vendor>
+       The optional "email" attribute specifies the e-mail address of the vendor.-->
+  <vendor url="http://www.jetbrains.com" email="support@jetbrains.com"</vendor>
 
   <!-- The unique identifiers of the plugins on which this plugin depends. -->
   <depends>MyFirstPlugin</depends>


### PR DESCRIPTION
Vendor logo is no longer used and including it in the xml produces a lint warning.