### PR TITLE
Remove orphaned closing tag from plugins.xml excerpt

### DIFF
--- a/tutorials/editor_basics/working_with_text.md
+++ b/tutorials/editor_basics/working_with_text.md
@@ -33,7 +33,7 @@ To register the action we should add a corresponding attribute to the `<actions>
         description="Illustrates how to plug an action in">
         <add-to-group group-id="EditorPopupMenu" anchor="last"/>
     </action>
-</action>
+</actions>
 ```
 
 If an action is registered in the group EditorPopupMenu, like the sample above shows,


### PR DESCRIPTION
There was an orphaned `action` closing tag. This repurposes it as a closing tag for the `actions` tag. Fixes the previous fix.