### PR TITLE
remove unused ModuleType/Builder#getBigIcon according to the commit.

### DIFF
--- a/code_samples/module/src/com/intellij/tutorials/module/DemoModuleType.java
+++ b/code_samples/module/src/com/intellij/tutorials/module/DemoModuleType.java
@@ -40,10 +40,6 @@ public class DemoModuleType extends ModuleType<DemoModuleBuilder> {
     return "Demo Module Type";
   }
 
-  @Override
-  public Icon getBigIcon() {
-    return AllIcons.General.Information;
-  }
 
   @Override
   public Icon getNodeIcon(@Deprecated boolean b) {

--- a/tutorials/project_wizard/module_types.md
+++ b/tutorials/project_wizard/module_types.md
@@ -56,10 +56,6 @@ public class DemoModuleType extends ModuleType<DemoModuleBuilder> {
         return "Demo Module Type";
     }
 
-    @Override
-    public Icon getBigIcon() {
-        return AllIcons.General.Information;
-    }
 
     @Override
     public Icon getNodeIcon(@Deprecated boolean b) {


### PR DESCRIPTION
Remove unused ModuleType/Builder#getBigIcon according to the commit: https://github.com/JetBrains/intellij-community/commit/a09fc34ef231220b4eb1a091bd2a25bedb25d085#diff-6180cd1c5f27463e1236dfdea209a49c

Otherwise the code won't compile in latest intellij version.