### PR TITLE
Updated 'msys git' to 'Git for Windows' as msys git is obsolete.

### DIFF
--- a/basics/checkout_and_build_community.md
+++ b/basics/checkout_and_build_community.md
@@ -4,7 +4,7 @@ title: Check Out And Build Community Edition
 
 ## Installing Git
 
-The source code of IntelliJ IDEA Community Edition is stored in a Git repository. Therefore, in order to check out the sources, you need to have Git installed. We recommend using the [msys git](https://msysgit.github.io) distribution on Windows and [git-osx-installer](http://code.google.com/p/git-osx-installer/) on Mac.
+The source code of IntelliJ IDEA Community Edition is stored in a Git repository. Therefore, in order to check out the sources, you need to have Git installed. We recommend using the [Git for Windows](http://gitforwindows.org/) distribution on Windows and [git-osx-installer](http://code.google.com/p/git-osx-installer/) on Mac.
 
 ## Checking Out the Code
 


### PR DESCRIPTION
The msys git website redirects to Git for Windows. See https://github.com/git-for-windows/git/wiki/FAQ#what-is-the-relationship-between-git-for-windows-and-msysgit