### PR TITLE
Use correct path to image resources.

### DIFF
--- a/reference_guide/work_with_icons_and_images.md
+++ b/reference_guide/work_with_icons_and_images.md
@@ -14,9 +14,9 @@ The `getIcon()` method of [`com.intellij.openapi.util.IconLoader`](upsource:///p
 
 ```java
 public interface DemoPluginIcons {
-  Icon STRUCTURE_TOOL_WINDOW = IconLoader.getIcon("/toolWindowStructure.png");
-  Icon MY_LANG_FILE_TYPE = IconLoader.getIcon("/myLangFileType.png");
-  Icon DEMO_ACTION = IconLoader.getIcon("/demoAction.png");
+  Icon STRUCTURE_TOOL_WINDOW = IconLoader.getIcon("/icons/toolWindowStructure.png");
+  Icon MY_LANG_FILE_TYPE = IconLoader.getIcon("/icons/myLangFileType.png");
+  Icon DEMO_ACTION = IconLoader.getIcon("/icons/demoAction.png");
 }
 ```
 


### PR DESCRIPTION
The 'best practices' recommends putting in subdirectory of resources, and the image actually shows the items in /resources/icons.