### PR TITLE
Remove passing a file extension explicitly.

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleFileTypeFactory.java
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleFileTypeFactory.java
@@ -6,6 +6,6 @@ import org.jetbrains.annotations.NotNull;
 public class SimpleFileTypeFactory extends FileTypeFactory {
   @Override
   public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-    fileTypeConsumer.consume(SimpleFileType.INSTANCE, "simple");
+    fileTypeConsumer.consume(SimpleFileType.INSTANCE);
   }
 }


### PR DESCRIPTION
Hello!

In this code, the `SimpleFileType` instance passed as the first argument and the `"simple"` file extension as the second parameter.

As far as I can see in FileTypeManagerImpl:263:
```java
@Override
public void consume(@NotNull FileType fileType) {
  register(fileType, parse(fileType.getDefaultExtension()));
}
```
There is no need to declare it explicitly as it is taken by calling `SimpleFileType.#getDefaultExtension()` by default, so this parameter is redundant.

To make tutorial more simple, I suggest this removal: seeing the second parameter is a bit confusing when we're passing the same value, returned from `getDefaultExtension()`.
Since the tutorial shows the basics, not a flexibility of an API, the parameter can be removed.

Thanks!