### PR TITLE
Fix a typo in tool_windows.md

### DIFF
--- a/user_interface_components/tool_windows.md
+++ b/user_interface_components/tool_windows.md
@@ -16,7 +16,7 @@ There are two main scenarios for the use of tool windows in a plugin.
 In the first scenario (used by the Ant and Commander plugins, for example), a tool window button is always visible, and the user can activate it and interact with the plugin functionality at any time.
 In the second scenario (used by the `Analyze Dependencies` action, for example), the tool window is created to show the results of a specific operation, and can be closed by the user after the operation is completed.
 
-In the first scenario, the tool window is registered in *plugin.xml* using the `<tool window>` extension point.
+In the first scenario, the tool window is registered in *plugin.xml* using the `<toolWindow>` extension point.
 The extension point attributes specify all the data which is necessary to display the tool window button:
 
 *  The `id` of the tool window (corresponds to the text displayed on the tool window button)


### PR DESCRIPTION
`<tool window>` --> `<toolWindow>`.
Refer to [PlatformExtensionPoints.xml](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/META-INF/PlatformExtensionPoints.xml#L148).