### PR TITLE
Eliminate meaning of curl '-k' option which disables SNI support

### DIFF
--- a/plugin_repository/api/plugin_upload.md
+++ b/plugin_repository/api/plugin_upload.md
@@ -20,13 +20,13 @@ Parameters:
 Provide file as file contents. Curl command template:
 
 ```
-curl -k -i -F userName=<userName> -F password=<password> -F pluginId=<pluginId> -F file=@<path to plugin .jar/.zip file> -F channel=<channel> https://plugins.jetbrains.com/plugin/uploadPlugin
+curl -i -F userName=<userName> -F password=<password> -F pluginId=<pluginId> -F file=@<path to plugin .jar/.zip file> -F channel=<channel> https://plugins.jetbrains.com/plugin/uploadPlugin
 ```
 
 Curl command example:
 
 ```
-curl -k -i -F userName=pluginrobot -F password=123456 -F pluginId=5047 -F file=@Go-0.11.1197.zip -F channel=nightly https://plugins.jetbrains.com/plugin/uploadPlugin
+curl -i -F userName=pluginrobot -F password=123456 -F pluginId=5047 -F file=@Go-0.11.1197.zip -F channel=nightly https://plugins.jetbrains.com/plugin/uploadPlugin
 ```
 
 **Using pluginXmlId**
@@ -34,11 +34,11 @@ curl -k -i -F userName=pluginrobot -F password=123456 -F pluginId=5047 -F file=@
 Provide file as file contents. Curl command template:
 
 ```
-curl -k -i -F userName=<userName> -F password=<password> -F xmlId=<pluginXmlId> -F file=@<path to plugin .jar/.zip file> -F channel=<channel> https://plugins.jetbrains.com/plugin/uploadPlugin
+curl -i -F userName=<userName> -F password=<password> -F xmlId=<pluginXmlId> -F file=@<path to plugin .jar/.zip file> -F channel=<channel> https://plugins.jetbrains.com/plugin/uploadPlugin
 ```
 
 Curl command example:
 
 ```
-curl -k -i -F userName=pluginrobot -F password=123456 -F xmlId=ro.redeul.google.go -F file=@Go-0.11.1197.zip -F channel=nightly https://plugins.jetbrains.com/plugin/uploadPlugin
+curl -i -F userName=pluginrobot -F password=123456 -F xmlId=ro.redeul.google.go -F file=@Go-0.11.1197.zip -F channel=nightly https://plugins.jetbrains.com/plugin/uploadPlugin
 ```


### PR DESCRIPTION
Fix of https://github.com/pantsbuild/intellij-pants-plugin/issues/332 & https://youtrack.jetbrains.com/issue/MP-1522
SNI support is a mandatory requirement of CDN.