### PR TITLE
Changed fallback character from . to [^].

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/Simple.flex
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/Simple.flex
@@ -41,4 +41,4 @@ KEY_CHARACTER=[^:=\ \n\t\f\\] | "\\ "
 
 ({CRLF}|{WHITE_SPACE})+                                     { yybegin(YYINITIAL); return TokenType.WHITE_SPACE; }
 
-.                                                           { return TokenType.BAD_CHARACTER; }
+[^]                                                         { return TokenType.BAD_CHARACTER; }


### PR DESCRIPTION
I am writing a plugin and ended up having a very weird crash in the editor when deleting tokens seemingly miles away from anything to do with lexing, it turns out [from reading various forum posts that IntelliJ ](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206119109-Editing-document-yields-exception-wrong-index-into-buffer) expects the lexer to always return tokens covering the document. 

Anyway in JFlex, the **.** character matches: `[^\n\r\u000B\u000C\u0085\u2028\u202 9]` , where as [^] matches any character of the input set. I believe that [^] is a safer default value to use here. In particular for me, my fallback rule ended up coming from the default documentation and was the ultimate source of my pain.

:warning: I'm just blindly making this change, and I'm not an expert. I also sadly didn't test this, since I no longer have the simple plugin setup, however I think this is safe.