### PR TITLE
Proper way to add plugin dependencies in gradle

### DIFF
--- a/basics/plugin_structure/plugin_dependencies.md
+++ b/basics/plugin_structure/plugin_dependencies.md
@@ -21,7 +21,7 @@ dependencies (e.g. Kotlin), you need to perform the following steps:
 
 ```groovy
 intellij {
-    plugins 'org.jetbrains.kotlin:1.2.30'
+    plugins "Kotlin"
 }
 ```
 


### PR DESCRIPTION
Adding this: `plugins 'org.jetbrains.kotlin:1.2.30'` to build script doesn't work and gives the following error message.
**Cannot find plugin org.jetbrains.kotlin:1.2.30 at https://plugins.jetbrains.com**

We need to give full version of the plugin like `plugins 'org.jetbrains.kotlin:1.2.70-release-IJ2018.2-1'` to work.

An easier way to do this is to simply mention `"Kotlin"`