### PR TITLE
ToolWindow example does not work with multiple windows

### DIFF
--- a/code_samples/tool_window/src/myToolWindow/MyToolWindow.form
+++ b/code_samples/tool_window/src/myToolWindow/MyToolWindow.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="myToolWindow.MyToolWindowFactory">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="myToolWindow.MyToolWindow">
   <grid id="27dc6" binding="myToolWindowContent" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>

--- a/code_samples/tool_window/src/myToolWindow/MyToolWindow.java
+++ b/code_samples/tool_window/src/myToolWindow/MyToolWindow.java
@@ -1,0 +1,63 @@
+package myToolWindow;
+
+import com.intellij.openapi.wm.ToolWindow;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.Calendar;
+
+public class MyToolWindow {
+    private JButton refreshToolWindowButton;
+    private JButton hideToolWindowButton;
+    private JLabel currentDate;
+    private JLabel currentTime;
+    private JLabel timeZone;
+    private JPanel myToolWindowContent;
+
+    public MyToolWindow(ToolWindow toolWindow) {
+        hideToolWindowButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                toolWindow.hide(null);
+            }
+        });
+        refreshToolWindowButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                currentDateTime();
+            }
+        });
+
+        this.currentDateTime();
+    }
+
+
+    public void currentDateTime() {
+        // Get current date and time
+        Calendar instance = Calendar.getInstance();
+        currentDate.setText(String.valueOf(instance.get(Calendar.DAY_OF_MONTH)) + "/"
+                                + String.valueOf(instance.get(Calendar.MONTH) + 1) + "/" +
+                                String.valueOf(instance.get(Calendar.YEAR)));
+        currentDate.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Calendar-icon.png")));
+        int min = instance.get(Calendar.MINUTE);
+        String strMin;
+        if (min < 10) {
+            strMin = "0" + String.valueOf(min);
+        } else {
+            strMin = String.valueOf(min);
+        }
+        currentTime.setText(instance.get(Calendar.HOUR_OF_DAY) + ":" + strMin);
+        currentTime.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Time-icon.png")));
+        // Get time zone
+        long gmt_Offset = instance.get(Calendar.ZONE_OFFSET); // offset from GMT in milliseconds
+        String str_gmt_Offset = String.valueOf(gmt_Offset / 3600000);
+        str_gmt_Offset = (gmt_Offset > 0) ? "GMT + " + str_gmt_Offset : "GMT - " + str_gmt_Offset;
+        timeZone.setText(str_gmt_Offset);
+        timeZone.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Time-zone-icon.png")));
+
+
+    }
+
+    public JPanel getContent() {
+        return myToolWindowContent;
+    }
+}

--- a/code_samples/tool_window/src/myToolWindow/MyToolWindowFactory.java
+++ b/code_samples/tool_window/src/myToolWindow/MyToolWindowFactory.java
@@ -4,10 +4,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.*;
 import com.intellij.ui.content.*;
 
-import javax.swing.*;
-import java.awt.event.*;
-import java.util.Calendar;
-
 /**
  * Created by IntelliJ IDEA.
  * User: Alexey.Chursin
@@ -15,63 +11,11 @@ import java.util.Calendar;
  * Time: 2:09:00 PM
  */
 public class MyToolWindowFactory implements ToolWindowFactory {
-
-  private JButton refreshToolWindowButton;
-  private JButton hideToolWindowButton;
-  private JLabel currentDate;
-  private JLabel currentTime;
-  private JLabel timeZone;
-  private JPanel myToolWindowContent;
-  private ToolWindow myToolWindow;
-
-
-  public MyToolWindowFactory() {
-    hideToolWindowButton.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        myToolWindow.hide(null);
-      }
-    });
-    refreshToolWindowButton.addActionListener(new ActionListener() {
-      public void actionPerformed(ActionEvent e) {
-        MyToolWindowFactory.this.currentDateTime();
-      }
-    });
-  }
-
   // Create the tool window content.
   public void createToolWindowContent(Project project, ToolWindow toolWindow) {
-    myToolWindow = toolWindow;
-    this.currentDateTime();
+    MyToolWindow myToolWindow = new MyToolWindow(toolWindow);
     ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
-    Content content = contentFactory.createContent(myToolWindowContent, "", false);
+    Content content = contentFactory.createContent(myToolWindow.getContent(), "", false);
     toolWindow.getContentManager().addContent(content);
-
   }
-
-  public void currentDateTime() {
-    // Get current date and time
-    Calendar instance = Calendar.getInstance();
-    currentDate.setText(String.valueOf(instance.get(Calendar.DAY_OF_MONTH)) + "/"
-                        + String.valueOf(instance.get(Calendar.MONTH) + 1) + "/" +
-                        String.valueOf(instance.get(Calendar.YEAR)));
-    currentDate.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Calendar-icon.png")));
-    int min = instance.get(Calendar.MINUTE);
-    String strMin;
-    if (min < 10) {
-      strMin = "0" + String.valueOf(min);
-    } else {
-      strMin = String.valueOf(min);
-    }
-    currentTime.setText(instance.get(Calendar.HOUR_OF_DAY) + ":" + strMin);
-    currentTime.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Time-icon.png")));
-    // Get time zone
-    long gmt_Offset = instance.get(Calendar.ZONE_OFFSET); // offset from GMT in milliseconds
-    String str_gmt_Offset = String.valueOf(gmt_Offset / 3600000);
-    str_gmt_Offset = (gmt_Offset > 0) ? "GMT + " + str_gmt_Offset : "GMT - " + str_gmt_Offset;
-    timeZone.setText(str_gmt_Offset);
-    timeZone.setIcon(new ImageIcon(getClass().getResource("/myToolWindow/Time-zone-icon.png")));
-
-
-  }
-
 }


### PR DESCRIPTION
The ToolWindow code example binds the form to the ToolWindowFactory instance, making its content available to only one project window at a time. It leads to content jumping from one window to the other.

Obviously, that is not the behavior any plugin developer would want, so I find the example very confusing. Apparently I'm not alone (see https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000625310-ToolWindow-Instantiation-for-each-project-opened)

I've changed the example minimally to create a separate bound class, to which each instance of the form can bind.