### PR TITLE
Fix Simple Language Plugin for latest IDEA version

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleLineMarkerProvider.java
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleLineMarkerProvider.java
@@ -13,7 +13,7 @@ public class SimpleLineMarkerProvider extends RelatedItemLineMarkerProvider {
   @Override
   protected void collectNavigationMarkers(@NotNull PsiElement element,
                                           Collection<? super RelatedItemLineMarkerInfo> result) {
-    if (element instanceof PsiLiteralExpression) {
+    if (element instanceof PsiLiteralExpression && element.getFirstChild() == null) {
       PsiLiteralExpression literalExpression = (PsiLiteralExpression) element;
       String value = literalExpression.getValue() instanceof String ? (String) literalExpression.getValue() : null;
       if (value != null && value.startsWith("simple" + ":")) {

--- a/code_samples/simple_language_plugin/testData/AnnotatorTestData.java
+++ b/code_samples/simple_language_plugin/testData/AnnotatorTestData.java
@@ -2,6 +2,6 @@ public class Test {
   public static void main(String[] args) {
     System.out.println("simple:website");
     System.out.println("simple:key with spaces");
-    System.out.println("simple:<error descr="Unresolved property">websit"</error>);
+    System.out.println("simple:<error descr=\"Unresolved property\">websit</error>");
   }
 }


### PR DESCRIPTION
Howdy,

I noticed the Simple Language Plugin's Annotator test fails with the latest IDEA SDK:

```
IntelliJ IDEA 2019.1 EAP (Community Edition)
Build #IC-191.SNAPSHOT, built on 10:23, November 7, 2018
JRE: 1.8.0_162-ea-b03 x86_64
JVM: Java HotSpot(TM) 64-Bit Server VM by Oracle Corporation
macOS 10.13.4
```

This PR does the following:

1. Fixes syntax errors in AnnotatorTestData.java

2. Prevents LineMarkerInfo from being registered on non-leaf elements

After these commits, the test suite passes.