### PR TITLE
Add a tip describing when you might want to override `PsiElement#getUseScope`

### DIFF
--- a/reference_guide/custom_language_support/find_usages.md
+++ b/reference_guide/custom_language_support/find_usages.md
@@ -84,3 +84,9 @@ passed to the provider in this case will be an instance of
 [ElementDescriptionProvider](upsource:///plugins/properties/src/com/intellij/lang/properties/PropertiesDescriptionProvider.java)
 for
 [Properties language plugin](upsource:///plugins/properties/)
+
+> **TIP** In cases like function parameters and local variables, consider overriding 
+[PsiElement#getUseScope](upsource:///platform/core-api/src/com/intellij/psi/PsiElement.java) to return a narrower scope. 
+For instance, you might return just the scope of the nearest function definition. This optimization can greatly reduce 
+the number of files that need to be parsed--and references that need to be resolved--when renaming a function parameter
+or local variable.


### PR DESCRIPTION
While digging through [intellij-rust](https://github.com/intellij-rust/intellij-rust) for tips/tricks, I noticed that they overrode `PsiElement#getUseScope` [for function parameters](https://github.com/intellij-rust/intellij-rust/blob/b34cb33882f46b9d57cef2d58beaa4907fcc1e2d/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt#L78). I was pleased to find this as it allowed me to make some nice improvements in my plugin [intellij-elm](https://github.com/klazuka/intellij-elm).

So I figured it would be good to add this to the documentation.