### PR TITLE
Add API breakage notice for GitCommitEditingAction

### DIFF
--- a/reference_guide/api_changes/api_changes_list_2019.md
+++ b/reference_guide/api_changes/api_changes_list_2019.md
@@ -22,6 +22,7 @@ See the note on how to document new problems on the main page reference_guide/ap
 | `kotlinx.coroutines.experimental` package removed | Bundled Kotlin library is updated to 1.3 so the plugins must [migrate](https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-3-rc-is-here-migrate-your-coroutines/) to the stable versions of coroutines. |
 | `com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl(Project, FileStatusManager, FileIndexFacade, ProjectManager, DefaultVcsRootPolicy, VcsFileListenerContextHelper)` constructor removed | Use `com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl.<init>(Project, FileStatusManager, FileIndexFacade, ProjectManager, DefaultVcsRootPolicy)` |
 | `com.intellij.injected.editor.DocumentWindow.injectedToHost(int, boolean)` abstract method added | Implement the method in DocumentWindow implementations |
+| `git4idea.rebase.GitCommitEditingAction#actionPerformed(AnActionEvent)` made final, abstract `git4idea.rebase.GitCommitEditingAction#actionPerformedAfterChecks(AnActionEvent)` added | Implement `actionPerformedAfterChecks` instead of `actionPerformed` |
 
 ## Changes in DataGrip and Database Tools plugin 2019.1
 


### PR DESCRIPTION
API was broken intentionally, the only usage was from internal plugin, which was promptly fixed.