### PR TITLE
Removed boilerplate code from example with lambdas

### DIFF
--- a/code_samples/tool_window/src/myToolWindow/MyToolWindow.java
+++ b/code_samples/tool_window/src/myToolWindow/MyToolWindow.java
@@ -16,16 +16,8 @@ public class MyToolWindow {
     private JPanel myToolWindowContent;
 
     public MyToolWindow(ToolWindow toolWindow) {
-        hideToolWindowButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                toolWindow.hide(null);
-            }
-        });
-        refreshToolWindowButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                currentDateTime();
-            }
-        });
+        hideToolWindowButton.addActionListener(e -> toolWindow.hide(null));
+        refreshToolWindowButton.addActionListener(e -> currentDateTime());
 
         this.currentDateTime();
     }


### PR DESCRIPTION
Given the advent of Java 8, anonymous classes for one-line commands are more visual distraction than they are helpful.
I replaced the two used here as action listeners for buttons with equivalent lambdas.