### PR TITLE
Make intellijPublishUsername and intellijPublishPassword optional

### DIFF
--- a/tutorials/build_system/deployment.md
+++ b/tutorials/build_system/deployment.md
@@ -24,8 +24,8 @@ Then refer to these values in `publishPlugin` task in your `build.gradle` file:
 
 ```groovy
 publishPlugin {
-    username intellijPublishUsername
-    password intellijPublishPassword
+    username findProperty('intellijPublishUsername')
+    password findProperty('intellijPublishPassword')
 }
 ```
 


### PR DESCRIPTION
The current guide with directly referencing `intellijPublishUsername` and `intellijPublishPassword` is somehow unpractical for plugin contributors that do not want to publish the plugin but expect the plugin project to work out of the box after checkout.  When they try to open the gradle project in IDEA they are faced with error messages like:
```
[...]
> Could not get unknown property 'intellijPublishUsername' for task ':publishPlugin' of type org.jetbrains.intellij.tasks.PublishTask.
[...]
```
Without fixing this error the project cannot be opened.  Users without gradle experience might give up at this point.  Therefore it's better to make these parameters optional.