### PR TITLE
updat quick start doc when version is above 2019.2 needs plugins 'java'

### DIFF
--- a/tutorials/build_system/prerequisites.md
+++ b/tutorials/build_system/prerequisites.md
@@ -121,6 +121,11 @@ The New Project Wizard produces the `my_gradle_plugin` project `build.gradle` fi
   
   // See https://github.com/JetBrains/gradle-intellij-plugin/
   intellij {
+      // you need to add plugins 'java' when you version is 2019.2
+      // See https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
+      // plugins 'java'
+      // version '2019.2'
+      
       version '2019.1'
   }
   patchPluginXml {

--- a/tutorials/build_system/prerequisites.md
+++ b/tutorials/build_system/prerequisites.md
@@ -121,7 +121,7 @@ The New Project Wizard produces the `my_gradle_plugin` project `build.gradle` fi
   
   // See https://github.com/JetBrains/gradle-intellij-plugin/
   intellij {
-      // you need to add plugins 'java' when you version is 2019.2
+      // you need to add plugins 'java' when your version is above 2019.2
       // See https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
       // plugins 'java'
       // version '2019.2'


### PR DESCRIPTION
As Matt Ellis said in post https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
In the latest EAP build of IntelliJ IDEA 2019.2 we’ve extracted Java functionality into a separate plugin.