### PR TITLE
Change IconLoader to IconManager

### DIFF
--- a/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleIcons.java
+++ b/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleIcons.java
@@ -1,9 +1,9 @@
 package com.simpleplugin;
 
-import com.intellij.openapi.util.IconLoader;
+import com.intellij.ui.IconManager;
 
 import javax.swing.*;
 
 public class SimpleIcons {
-  public static final Icon FILE = IconLoader.getIcon("/com/simpleplugin/icons/jar-gray.png");
+  public static final Icon FILE = IconManager.getInstance().getIcon("/com/simpleplugin/icons/jar-gray.png", SimpleIcons.class);
 }


### PR DESCRIPTION
This changes IconLoader to IconManager just for the simpleplugin demo as I found it while reading the tutorial.
I'm willing to change this for all occurences of the IconLoader in this rep, just wanted to make sure this is wanted.