### PR TITLE
Update annotator.md

### DIFF
--- a/tutorials/custom_language_support/annotator.md
+++ b/tutorials/custom_language_support/annotator.md
@@ -34,13 +34,13 @@ public class SimpleAnnotator implements Annotator {
         String key = value.substring(7);
         List<SimpleProperty> properties = SimpleUtil.findProperties(project, key);
         if (properties.size() == 1) {
-          TextRange range = new TextRange(element.getTextRange().getStartOffset() + 7,
-                                          element.getTextRange().getEndOffset());
+          TextRange range = new TextRange(element.getTextRange().getStartOffset() + 8,
+                                          element.getTextRange().getEndOffset() - 1);
           Annotation annotation = holder.createInfoAnnotation(range, null);
           annotation.setTextAttributes(DefaultLanguageHighlighterColors.LINE_COMMENT);
         } else if (properties.size() == 0) {
           TextRange range = new TextRange(element.getTextRange().getStartOffset() + 8,
-                                          element.getTextRange().getEndOffset());
+                                          element.getTextRange().getEndOffset() - 1);
           holder.createErrorAnnotation(range, "Unresolved property");
         }
       }


### PR DESCRIPTION
若startOffset不+1，则会包含“website”左侧的冒号；若endOffset不-1，则会包含“website”右侧的引号，两种情况都怪怪的。
if we don't +1 for the 'startOffset', then the colon at the left side of "website" will be included; if we don't -1 for the 'endOffset', then the quote mark at the right side of "website" will be included, and both of them are strange.

另，github仓库的源码（https://github.com/JetBrains/intellij-sdk-docs/blob/master/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleAnnotator.java ）有误，如下：
btw，the source code in the repository in github(https://github.com/JetBrains/intellij-sdk-docs/blob/master/code_samples/simple_language_plugin/src/com/simpleplugin/SimpleAnnotator.java) is wrong as below:

```
//line 24:
if (properties.size() == 1) {
          TextRange range = new TextRange(element.getTextRange().getStartOffset() + 7,
                                          element.getTextRange().getStartOffset() + 7);
//new TextRange时endOffset跟startOffset相同。
//endOffset is the same as startOffset while new TextRange.
```