### PR TITLE
Update implementing_lexer.md: Patched JFlex moved

### DIFF
--- a/reference_guide/custom_language_support/implementing_lexer.md
+++ b/reference_guide/custom_language_support/implementing_lexer.md
@@ -40,14 +40,16 @@ method, along with the start offset of the fragment to process, when lexing is r
 Lexers used in other contexts can always return `0` from the `getState()` method.
 
 The easiest way to create a lexer for a custom language plugin is to use [JFlex](https://jflex.de).
-Adapter classes,
+Classes
 [FlexLexer](upsource:///platform/core-api/src/com/intellij/lexer/FlexLexer.java)
 and
 [FlexAdapter](upsource:///platform/core-api/src/com/intellij/lexer/FlexAdapter.java)
 adapt JFlex lexers to the IntelliJ Platform Lexer API.
-The source code of
+We have a
+[patched version of JFlex](https://github.com/JetBrains/intellij-deps-jflex)
+that can be used with the lexer skeleton file located at *tools/lexer/idea-flex.skeleton* in the
 [IntelliJ IDEA Community Edition](https://github.com/JetBrains/intellij-community)
-includes a patched version of JFlex 1.4 located in *tools/lexer/jflex-1.4* and lexer skeleton file *tools/lexer/idea-flex.skeleton* which can be used for creating lexers compatible with
+source to create lexers compatible with
 [FlexAdapter](upsource:///platform/core-api/src/com/intellij/lexer/FlexAdapter.java).
 The patched version of JFlex provides a new command line option `--charat` which changes the JFlex generated code so that it works with the IntelliJ Platform skeleton.
 Enabling `--charat` option passes the source data for lexing as a


### PR DESCRIPTION
This broke the parallelism, so I had to rewrite nearly that whole sentence.
I also removed mention of the JFlex version number, which turned out to be a good idea as it seems that the IntelliJ fork is presently based on something like JFlex 1.7.0.

While checking my changes, I noticed that the sentence before that one looked a bit funny and fixed that, too.