### PR TITLE
Document move of FocusDegree to Lookup

### DIFF
--- a/reference_guide/api_changes/api_changes_list_2019.md
+++ b/reference_guide/api_changes/api_changes_list_2019.md
@@ -61,6 +61,9 @@ NOTE: You are allowed to prettify the pattern using markdown-features:
 
 ## Changes in IntelliJ Platform 2019.3
 
+`com.intellij.codeInsight.lookup.impl.LookupImpl.FocusDegree` class removed
+: Use `com.intellij.codeInsight.lookup.Lookup.FocusDegree` instead.
+
 `com.intellij.json.JsonFileTypeFactory` class removed
 : Use `com.intellij.fileType` extension point instead.
 


### PR DESCRIPTION
Affects only kotlin usages, in java it is still possible to access moved class as LookupImpl.FocusDegree.