### PR TITLE
Add Haulmont to the list of 3rd party consulting

### DIFF
--- a/appendix/resources/consulting.md
+++ b/appendix/resources/consulting.md
@@ -12,5 +12,6 @@ The following independent companies and individuals provide paid plugin consulti
 | Daniel Espendiller | [daniel@espendiller.net](daniel@espendiller.net) | -/- |
 | Robert Ekendahl | [www.edaphic.studio](https://www.edaphic.studio) | Custom Language support |
 | Patrick Scheibe | [www.halirutan.de](https://halirutan.de/) | Plugins: [Wolfram Language](https://plugins.jetbrains.com/plugin/7232-wolfram-language), [Key Promoter X](https://plugins.jetbrains.com/plugin/9792-key-promoter-x). Highly active in the [#intellij-platform on JetBrains Platform Slack](https://plugins.jetbrains.com/slack/). 
+| Alexey Stukalov | [info@cuba-platform.com](mailto:info@cuba-platform.com), [www.haulmont.com](https://www.haulmont.com/services/cuba-platform-services/support/) | Plugins: [CUBA](https://plugins.jetbrains.com/plugin/7249-cuba). 
 
 Please [submit a PR or file a YouTrack issue](/intro/getting_help.md) for changes or additions to this list.


### PR DESCRIPTION
Add Haulmont to the list of 3rd party consulting companies on the Consulting page.