### PR TITLE
Fix typo

### DIFF
--- a/code_samples/simple_language_plugin/src/main/resources/META-INF/plugin.xml
+++ b/code_samples/simple_language_plugin/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
   <version>2.0.0</version>
 
   <!-- Compatible with the following versions of IntelliJ Platform
-        At least 2019.2 is required. Otherwise, FileTypeFactor must be registered as an extension.
+        At least 2019.2 is required. Otherwise, FileTypeFactory must be registered as an extension.
         See the extensions section below. -->
   <idea-version since-build="192.2"/>
 


### PR DESCRIPTION
While going through the code sample of the simple language plugin demo, I just found a very little typo.