### PR TITLE
Corrected the file name in plugin.xml

### DIFF
--- a/tutorials/custom_language_support/language_and_filetype.md
+++ b/tutorials/custom_language_support/language_and_filetype.md
@@ -41,7 +41,7 @@ Instead, the file type is registered of file type is done via the `com.intellij.
 
 ```xml
   <extensions defaultExtensionNs="com.intellij">
-    <fileType name="Simple file" implementationClass="org.intellij.sdk.language.SimpleFileType" 
+    <fileType name="Simple File" implementationClass="org.intellij.sdk.language.SimpleFileType" 
             fieldName="INSTANCE" language="Simple" extensions="simple"/>
   </extensions>
 ```


### PR DESCRIPTION
When run the project as per documentation gives an error 
```
2020-04-28 20:13:40,701 [   5378]  ERROR - Types.impl.FileTypeManagerImpl - Incorrect name specified in <fileType>, should be Simple File, actual Simple file [Plugin: org.example.SimplePlugin] 
```
Fixed this error by correcting the name. 