### PR TITLE
Include the sourceSet rune for kotlin gradle

### DIFF
--- a/tutorials/custom_language_support/lexer_and_parser_definition.md
+++ b/tutorials/custom_language_support/lexer_and_parser_definition.md
@@ -19,6 +19,11 @@ To include those files, the project's `sourceSets` must be expanded by inserting
   sourceSets.main.java.srcDirs 'src/main/gen'
 ```
 
+Or the following line in the project's `build.gradle.kts` file:
+```kotlin
+  sourceSets["main"].java.srcDirs("src/main/gen")
+```
+
 ## 4.1. Define a Lexer
 Define a `Simple.flex` file with rules for the Simple Language lexer, as demonstrated in `org.intellij.sdk.language.Simple.flex`.
 


### PR DESCRIPTION
Include to necessary rune for kotlin based gradle files to assist people starting from the JetBrains/intellij-platform-plugin-template repo, which uses `build.gradle.kts` by default.

Related issue: JetBrains/intellij-platform-plugin-template#17