### PR TITLE
Add information about breaking changes in SpellChecker

### DIFF
--- a/reference_guide/api_changes/api_changes_list_2020.md
+++ b/reference_guide/api_changes/api_changes_list_2020.md
@@ -78,6 +78,9 @@ Please see [Incompatible API Changes](/reference_guide/api_changes_list.md) on h
 `com.intellij.util.indexing.FileContentImpl(VirtualFile, byte[])` constructor removed
 : Constructors of `FileContentImpl` were replaced with factory methods. Use `FileContentImpl#createByContent(VirtualFile, byte[])`
 
+`com.intellij.spellchecker.tokenizer.SpellcheckingStrategy.getDefaultRegularFixes(boolean, String, @Nullable PsiElement)` method removed
+: method replaced with `com.intellij.spellchecker.tokenizer.SpellcheckingStrategy.getDefaultRegularFixes(boolean, String, @Nullable PsiElement, @NotNull TextRange)`
+
 ### Changes in Java Plugin 2019.3
 
 The PSI structure of multi-dimensional arrays in Java source files changed (see `com.intellij.psi.PsiTypeElement`)


### PR DESCRIPTION
`com.intellij.spellchecker.tokenizer.SpellcheckingStrategy.getDefaultRegularFixes(boolean, String, @Nullable PsiElement)` method removed