### PR TITLE
Information about incompatible spellchecker changes

### DIFF
--- a/reference_guide/api_changes/api_changes_list_2020.md
+++ b/reference_guide/api_changes/api_changes_list_2020.md
@@ -78,6 +78,9 @@ Please see [Incompatible API Changes](/reference_guide/api_changes_list.md) on h
 `com.intellij.util.indexing.FileContentImpl(VirtualFile, byte[])` constructor removed
 : Constructors of `FileContentImpl` were replaced with factory methods. Use `FileContentImpl#createByContent(VirtualFile, byte[])`
 
+`com.intellij.spellchecker.quickfixes.ChangeTo(java.lang.String)` constructor removed
+: Constructor was replaced with `com.intellij.spellchecker.quickfixes.ChangeTo.<init>(String, PsiElement, TextRange)`
+
 ### Changes in Java Plugin 2019.3
 
 The PSI structure of multi-dimensional arrays in Java source files changed (see `com.intellij.psi.PsiTypeElement`)


### PR DESCRIPTION
Add information about removal of `com.intellij.spellchecker.quickfixes.ChangeTo.<init>(java.lang.String)`