### PR TITLE
docs: update getIcon usage

### DIFF
--- a/reference_guide/work_with_icons_and_images.md
+++ b/reference_guide/work_with_icons_and_images.md
@@ -26,9 +26,9 @@ Then define a class/interface in a top-level package called `icons` holding icon
 package icons;
 
 public interface DemoPluginIcons {
-  Icon DemoAction = IconLoader.getIcon("/icons/demoAction.png");
-  Icon StructureToolWindow = IconLoader.getIcon("/icons/toolWindowStructure.png");
-  Icon FileType = IconLoader.getIcon("/icons/myLangFileType.png");
+  Icon DemoAction = IconLoader.getIcon("/icons/demoAction.png", DemoPluginIcons.class);
+  Icon StructureToolWindow = IconLoader.getIcon("/icons/toolWindowStructure.png", DemoPluginIcons.class);
+  Icon FileType = IconLoader.getIcon("/icons/myLangFileType.png", DemoPluginIcons.class);
 }
 ```
 
@@ -40,7 +40,7 @@ package icons
 object DemoPluginIcons {
   
   @JvmField
-  val DemoAction = IconLoader.getIcon("/icons/demoAction.png")
+  val DemoAction = IconLoader.getIcon("/icons/demoAction.png", javaClass)
 
   // ...
 }


### PR DESCRIPTION
### Motivation

As I was browsing the [documentation](https://jetbrains.org/intellij/sdk/docs/reference_guide/work_with_icons_and_images.html#how-to-organize-and-how-to-use-icons), the `com.intellij.openapi.util.IconLoader#getIcon(@NonNls @NotNull String path)` would now be deprecated and it would be better to show the recommended method to be used which is `com.intellij.openapi.util.IconLoader#getIcon(@NotNull String path, @NotNull Class<?> aClass)` that uses a class for the 2nd parameter. So newer code would not encounter deprecations when they target the new platform build.
