### PR TITLE
Fix DemoRunConfigurationType id naming

### DIFF
--- a/tutorials/run_configurations.md
+++ b/tutorials/run_configurations.md
@@ -45,7 +45,7 @@ public class DemoRunConfigurationType implements ConfigurationType {
     @NotNull
     @Override
     public String getId() {
-        return "DEMO_RUN_CONFIGURATION";
+        return "DemoRunConfiguration";
     }
 
     @Override


### PR DESCRIPTION
ConfigurationType.getId() javadoc says "The ID of the configuration type. Should be camel-cased without dashes, underscores, spaces and quotation marks."