### PR TITLE
Declare removed method

### DIFF
--- a/reference_guide/api_changes/api_changes_list_2021.md
+++ b/reference_guide/api_changes/api_changes_list_2021.md
@@ -67,5 +67,5 @@ Please see [Incompatible API Changes](/reference_guide/api_changes_list.md) on h
 ### Changes in IntelliJ Platform 2021.1
 
 com.intellij.util.io.PersistentHashMap.isCorrupted() method removed
-
+: the storage checks for corrupted automatically, there is no need of any explicit additional checks. This method was indended for tests only
 

--- a/reference_guide/api_changes/api_changes_list_2021.md
+++ b/reference_guide/api_changes/api_changes_list_2021.md
@@ -65,3 +65,7 @@ Please see [Incompatible API Changes](/reference_guide/api_changes_list.md) on h
 ## 2021.1
                               
 ### Changes in IntelliJ Platform 2021.1
+
+com.intellij.util.io.PersistentHashMap.isCorrupted() method removed
+
+


### PR DESCRIPTION
This is a ```@TestOnly``` method used in Scala. We will update the Scala plugin to remove that use.