### PR TITLE
remove psiImplUtilClass from Grammar and Parser page

### DIFF
--- a/tutorials/custom_language_support/grammar_and_parser.md
+++ b/tutorials/custom_language_support/grammar_and_parser.md
@@ -42,8 +42,6 @@ Define a grammar for the Simple Language in the `com/intellij/sdk/language/Simpl
   elementTypeHolderClass="org.intellij.sdk.language.psi.SimpleTypes"
   elementTypeClass="org.intellij.sdk.language.psi.SimpleElementType"
   tokenTypeClass="org.intellij.sdk.language.psi.SimpleTokenType"
-
-  psiImplUtilClass="org.intellij.sdk.language.psi.impl.SimplePsiImplUtil"
 }
 
 simpleFile ::= item_*


### PR DESCRIPTION
Remove the definition of psiImplUtilClass in the Grammar and Parser page. With this file added, it is not possible to successfully compile the Sourcecode used for the Tutorial at this point. Later on in chapter 6.2 this line gets added, also with a link back to chapter 3.3.
This is also something that confused me, while reading the tutorial the first time.