### PR TITLE
API changes notes for IDEA-261957

### DIFF
--- a/reference_guide/api_changes_list_2021.md
+++ b/reference_guide/api_changes_list_2021.md
@@ -97,3 +97,14 @@ Please see [Incompatible API Changes](api_changes_list.md) on how to verify comp
 `com.jetbrains.performancePlugin.CommandProvider.getCommands(Project)` method parameter `Project` removed
 : Project is now only accessible via `com.intellij.openapi.ui.playback.PlaybackContext.getProject()` since it may change during script execution. 
 
+`com.intellij.ws.rest.client` package removed
+: Replaced by `com.intellij.httpClient.execution` in HTTP Client plugin
+
+`com.intellij.ws.actions` package removed
+: Replaced by `com.intellij.httpClient.actions` in HTTP Client plugin
+
+`com.intellij.ws.converters` package removed
+: Replaced by `com.intellij.httpClient.converters` in HTTP Client plugin
+
+`com.intellij.ws.http.request` package removed
+: Replaced by `com.intellij.httpClient.http.request` in HTTP Client plugin


### PR DESCRIPTION
Rename `com.intellij.ws` package to `com.intellij.httpClient` in HTTP Client plugin