### PR TITLE
Documentation for Element Patterns

### DIFF
--- a/ijs.tree
+++ b/ijs.tree
@@ -179,7 +179,7 @@
             <toc-element id="file_based_indexes.md" toc-title="File-Based Indexes"/>
             <toc-element id="stub_indexes.md" toc-title="Stub Indexes"/>
         </toc-element>
-        <toc-element toc-title="Element Patterns"/>
+        <toc-element id="element_patterns.md" toc-title="Element Patterns"/>
         <toc-element toc-title="Unified AST"/>
         <toc-element id="xml_dom_api.md" toc-title="XML DOM API"/>
     </toc-element>

--- a/topics/basics/architectural_overview/element_patterns.md
+++ b/topics/basics/architectural_overview/element_patterns.md
@@ -1,0 +1,110 @@
+[//]: # (title: Element Patterns)
+
+<!-- Copyright 2000-2021 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+
+Element patterns provide a generic way to specify conditions on objects. Plugin authors use them to check whether PSI elements match a particular structure. Just as regular expressions for strings test whether a (sub-)string matches a particular pattern, element patterns are used to put conditions on the nested structure of PSI elements. Their two main applications inside the _IntelliJ Platform_ are:
+
+1. Specifying where auto-completion should occur when implementing [a completion contributor](https://plugins.jetbrains.com/docs/intellij/completion-contributor.html) for a custom language.
+2. Specifying PSI elements that provide further references via [a PSI reference contributor](https://plugins.jetbrains.com/docs/intellij/psi-references.html#contributed-references).
+
+However, plugin authors rarely implement the [`ElementPattern`](upsource:///platform/core-api/src/com/intellij/patterns/ElementPattern.java) interface directly.
+Instead, we recommend using the high-level pattern classes provided by the _IntelliJ Platform_:
+
+| Class                                    | Main Contents                                                                                                             | Notable Examples                                                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`StandardPatterns`](upsource:///platform/core-api/src/com/intellij/patterns/StandardPatterns.java)     | Factory for string and char pattern (see below); Logical operations like and, or, not                                     | [`LogbackReferenceContributor.kt`](upsource:///plugins/groovy/src/org/jetbrains/plugins/groovy/ext/logback/LogbackReferenceContributor.kt), [`RegExpCompletionContributor`](upsource:///RegExpSupport/src/org/intellij/lang/regexp/RegExpCompletionContributor.java)                                 |
+| [`PlatformPatterns`](upsource:///platform/core-api/src/com/intellij/patterns/PlatformPatterns.java)     | Factory for PSI-, IElement-, and VirtualFile-patterns                                                                      | [`FxmlReferencesContributor`](upsource:///plugins/javaFX/src/org/jetbrains/plugins/javaFX/fxml/refs/FxmlReferencesContributor.java), [`PyDataclassCompletionContributor.kt`](upsource:///python/python-psi-impl/src/com/jetbrains/python/codeInsight/completion/PyDataclassCompletionContributor.kt) |
+| [`PsiElementPattern`](upsource:///platform/core-api/src/com/intellij/patterns/PsiElementPattern.java)   | Patterns for PSI; Checks for children, parents, or neighboring leaves                                                     | [`XmlCompletionContributor`](upsource:///xml/impl/src/com/intellij/codeInsight/completion/XmlCompletionContributor.java)                                                           |
+| [`CollectionPattern`](upsource:///platform/core-api/src/com/intellij/patterns/CollectionPattern.java)   | Filter and check pattern collections; Mainly used to provide functionality for other high-level pattern classes           | [`PsiElementPattern`](upsource:///platform/core-api/src/com/intellij/patterns/PsiElementPattern.java)                                                                                                                                                                                               |
+| [`TreeElementPattern`](upsource:///platform/core-api/src/com/intellij/patterns/TreeElementPattern.java) | Patterns specifically for checking (PSI) tree structure                                                                   | [`PyMetaClassCompletionContributor`](upsource:///python/python-psi-impl/src/com/jetbrains/python/codeInsight/completion/PyMetaClassCompletionContributor.java)                                                                                                                                      |
+| [`StringPattern`](upsource:///platform/core-api/src/com/intellij/patterns/StringPattern.java)           | Check if strings match, have a certain length, have a specific beginning or ending, or are one of a collection of strings | [`AbstractGradleCompletionContributor.kt`](upsource:///plugins/gradle/java/src/codeInsight/AbstractGradleCompletionContributor.kt)                                                                                                                                                                  |
+| [`CharPattern`](upsource:///platform/core-api/src/com/intellij/patterns/CharPattern.java)               | Check if characters are whitespace, digits, or Java identifier parts                                                      | [`CompletionUtil`](upsource:///platform/analysis-impl/src/com/intellij/codeInsight/completion/CompletionUtil.java)                                                                                                                                                                                  |
+
+Some built-in languages in the _IntelliJ Platform_ implement their own pattern classes and can provide additional examples:
+
+- [`XmlPatterns`](upsource:///xml/xml-psi-api/src/com/intellij/patterns/XmlPatterns.java) provides patterns for XML attributes, values, entities, and texts.
+- [`PythonPatterns`](upsource:///python/src/com/jetbrains/python/patterns/PythonPatterns.java) provides patterns for literals, strings, arguments, and function/method arguments for Python.
+- [`DomPatterns`](upsource:///xml/dom-openapi/src/com/intellij/patterns/DomPatterns.java) builds upon XmlPatterns and acts as a wrapper to provide further patterns for [DOM-API](https://plugins.jetbrains.com/docs/intellij/xml-dom-api.html).
+
+## Examples
+
+A good starting point for element patterns is the [Custom Language Support Tutorial](https://plugins.jetbrains.com/docs/intellij/custom-language-support-tutorial.html).
+They are used in the [completion](https://plugins.jetbrains.com/docs/intellij/completion-contributor.html#define-a-completion-contributor) and [reference](https://plugins.jetbrains.com/docs/intellij/reference-contributor.html#define-a-reference-contributor) contributor section of the tutorial.
+However, the _IntelliJ Platform_ source code provides many more examples of element patterns for built-in languages like JSON, XML, Groovy, Markdown, and so on.
+Checking the references in the table above or searching for usages of the high-level pattern classes will provide a comprehensive list that shows how element patterns are used in production code.
+
+For instance, an example can be found in [`MarkdownReferenceProvider`](upsource:///plugins/markdown/src/org/intellij/plugins/markdown/lang/references/MarkdownReferenceProvider.java) that tests if a PSI element is an instance of the `MarkdownLinkDestinationImpl` class and appears in a Markdown file.
+
+```java
+PsiElementPattern.Capture<MarkdownLinkDestinationImpl> linkDestinationCapture =
+  psiElement(MarkdownLinkDestinationImpl.class).
+  inFile(psiFile(MarkdownFile.class));
+```
+
+As shown in the code above, element patterns can be stacked and combined to create more complex conditions.
+[`JsonCompletionContributor`](upsource:///json/src/com/intellij/json/codeinsight/JsonCompletionContributor.java) contains another example with more requirements on the PSI element.
+
+```java
+PsiElementPattern.Capture<PsiElement> AFTER_COMMA_OR_BRACKET_IN_ARRAY =
+  psiElement().
+  afterLeaf("[", ",").
+  withSuperParent(2,JsonArray.class).
+  andNot(
+    psiElement().
+    withParent(JsonStringLiteral.class)
+  );
+```
+
+The above pattern makes sure that the PSI element:
+
+1. Appears after either an open bracket or a comma, which is expressed by putting a restriction on the neighboring leaf element.
+2. Has `JsonArray` as a level-two parent, which indicates that the PSI element must be inside a JSON array.
+3. Does not have a `JsonStringLiteral` as a parent, which prevents situations where a string with a bracket or comma inside an array would give a false-positive match.
+
+This last example shows that corner cases need to be considered carefully even for simple patterns.
+
+## Tools and Debugging
+
+Working with element patterns can be tricky, and plugin authors need a solid understanding of the underlying PSI structure to get it right.
+Therefore, it is recommended to use the [PsiViewer plugin](https://plugins.jetbrains.com/plugin/227-psiviewer) or the [built-in PSI viewer](https://www.jetbrains.com/help/idea/psi-viewer.html) and verify that elements indeed have the expected structure and properties.
+
+### Debugging
+
+For this section, it is assumed that plugin authors have a basic understanding of how to work with [a debugger](https://www.jetbrains.com/help/idea/debugging-code.html), how to [set breakpoints](https://www.jetbrains.com/help/idea/using-breakpoints.html#set-breakpoints), and how to set [conditions on breakpoints](https://www.jetbrains.com/help/idea/using-breakpoints.html#properties).
+
+When debugging element patterns, plugin authors need to keep in mind that the places where element patterns are instantiated are unrelated to where they are actually used.
+For instance, while patterns for completion contributors are instantiated when registering the contributor, the patterns are checked during completion while typing.
+Therefore, finding the correct locations in the _IntelliJ Platform_ for debugging element patterns is the first important step.
+
+However, setting breakpoints inside `ElementPattern` will result in many false-positives since element patterns are used extensively throughout the IDE.
+One way to filter out these false-positives is to use a condition on the breakpoints.
+The following steps can help you investigate where patterns are checked:
+
+1. Set breakpoints at the `ElementPattern#accepts` methods.
+2. Set a condition on the breakpoints that checks whether the string representation of the pattern contains an _identifiable part_ of the pattern.
+3. Debug, and when the breakpoint triggers, make sure it is the right pattern and investigate the call stack to find relevant methods that use the pattern check.
+4. Debug the relevant methods, e.g. methods that fill completion variants or find references.
+
+Note that finding an identifiable part of a pattern can be achieved by setting a breakpoint where the pattern is **instantiated** and checking its string representation.
+
+### Debugging Example
+
+Using the Markdown code example from above, we note that the `MarkdownLinkDestinationImpl` class is used in the element pattern.
+Now, set a breakpoint at:
+
+```java
+com.intellij.patterns.ElementPattern#accepts(
+  java.lang.Object,
+  com.intellij.util.ProcessingContext
+)
+```
+
+Right-click on the breakpoint and set the following as a condition:
+
+```java
+toString().contains("MarkdownLinkDestinationImpl")
+```
+
+Now start a debug session and open a Markdown file.
+When the breakpoint hits, the call stack in the [debug tool window](https://www.jetbrains.com/help/idea/debug-tool-window.html) shows that reference-providers are checked in the method `doGetReferencesFromProviders` within [`ReferenceProvidersRegistryImpl`](upsource:///platform/core-impl/src/com/intellij/psi/impl/source/resolve/reference/ReferenceProvidersRegistryImpl.java).
+This provides a good starting point for further investigation.


### PR DESCRIPTION
This adds the article for Element Patterns. Notes:

- [x] Checked that all upsource links are working
- [x] Removed `JsonPathCompletionContributor` from the examples since it seems only available in the latest master and not the 203 sources