### PR TITLE
Make the style of "IntelliJ Platform" consistent throughout the docs.

### DIFF
--- a/topics/appendix/resources/useful_links.md
+++ b/topics/appendix/resources/useful_links.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The following links represent useful resources for working with the _IntelliJ Platform_ and creating plugins.
+The following links represent useful resources for working with the IntelliJ Platform and creating plugins.
 
 ### Repositories
 * [IntelliJ SDK Documentation](https://github.com/JetBrains/intellij-sdk-docs)

--- a/topics/basics/architectural_overview/documents.md
+++ b/topics/basics/architectural_overview/documents.md
@@ -5,7 +5,7 @@
 A [`Document`](upsource:///platform/core-api/src/com/intellij/openapi/editor/Document.java) is an editable sequence of Unicode characters, typically corresponding to the text contents of a [virtual file](virtual_file.md).
 
 Line breaks in a document are _always_ normalized to `\n`.
-The *IntelliJ Platform* handles encoding and line break conversions when loading and saving documents transparently.
+The IntelliJ Platform handles encoding and line break conversions when loading and saving documents transparently.
 
 ## How do I get a document?
 

--- a/topics/basics/architectural_overview/element_patterns.md
+++ b/topics/basics/architectural_overview/element_patterns.md
@@ -2,13 +2,13 @@
 
 <!-- Copyright 2000-2021 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-Element patterns provide a generic way to specify conditions on objects. Plugin authors use them to check whether PSI elements match a particular structure. Just as regular expressions for strings test whether a (sub-)string matches a particular pattern, element patterns are used to put conditions on the nested structure of PSI elements. Their two main applications inside the _IntelliJ Platform_ are:
+Element patterns provide a generic way to specify conditions on objects. Plugin authors use them to check whether PSI elements match a particular structure. Just as regular expressions for strings test whether a (sub-)string matches a particular pattern, element patterns are used to put conditions on the nested structure of PSI elements. Their two main applications inside the IntelliJ Platform are:
 
 1. Specifying where auto-completion should occur when implementing [a completion contributor](completion_contributor.md) for a custom language.
 2. Specifying PSI elements that provide further references via [a PSI reference contributor](psi_references.md#contributed-references).
 
 However, plugin authors rarely implement the [`ElementPattern`](upsource:///platform/core-api/src/com/intellij/patterns/ElementPattern.java) interface directly.
-Instead, we recommend using the high-level pattern classes provided by the _IntelliJ Platform_:
+Instead, we recommend using the high-level pattern classes provided by the IntelliJ Platform:
 
 | Class                                    | Main Contents                                                                                                             | Notable Examples                                                                                                                              |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -20,7 +20,7 @@ Instead, we recommend using the high-level pattern classes provided by the _Inte
 | [`StringPattern`](upsource:///platform/core-api/src/com/intellij/patterns/StringPattern.java)           | Check if strings match, have a certain length, have a specific beginning or ending, or are one of a collection of strings | [`AbstractGradleCompletionContributor.kt`](upsource:///plugins/gradle/java/src/codeInsight/AbstractGradleCompletionContributor.kt)                                                                                                                                                                  |
 | [`CharPattern`](upsource:///platform/core-api/src/com/intellij/patterns/CharPattern.java)               | Check if characters are whitespace, digits, or Java identifier parts                                                      | [`CompletionUtil`](upsource:///platform/analysis-impl/src/com/intellij/codeInsight/completion/CompletionUtil.java)                                                                                                                                                                                  |
 
-Some built-in languages in the _IntelliJ Platform_ implement their own pattern classes and can provide additional examples:
+Some built-in languages in the IntelliJ Platform implement their own pattern classes and can provide additional examples:
 
 - [`XmlPatterns`](upsource:///xml/xml-psi-api/src/com/intellij/patterns/XmlPatterns.java) provides patterns for XML attributes, values, entities, and texts.
 - [`PythonPatterns`](upsource:///python/src/com/jetbrains/python/patterns/PythonPatterns.java) provides patterns for literals, strings, arguments, and function/method arguments for Python.
@@ -30,7 +30,7 @@ Some built-in languages in the _IntelliJ Platform_ implement their own pattern c
 
 A good starting point for element patterns is the [Custom Language Support Tutorial](custom_language_support_tutorial.md).
 They are used in the [completion](completion_contributor.md#define-a-completion-contributor) and [reference](reference_contributor.md#define-a-reference-contributor) contributor section of the tutorial.
-However, the _IntelliJ Platform_ source code provides many more examples of element patterns for built-in languages like JSON, XML, Groovy, Markdown, and so on.
+However, the IntelliJ Platform source code provides many more examples of element patterns for built-in languages like JSON, XML, Groovy, Markdown, and so on.
 Checking the references in the table above or searching for usages of the high-level pattern classes will provide a comprehensive list that shows how element patterns are used in production code.
 
 For instance, an example can be found in [`MarkdownReferenceProvider`](upsource:///plugins/markdown/src/org/intellij/plugins/markdown/lang/references/MarkdownReferenceProvider.java) that tests if a PSI element is an instance of the `MarkdownLinkDestinationImpl` class and appears in a Markdown file.
@@ -74,7 +74,7 @@ For this section, it is assumed that plugin authors have a basic understanding o
 
 When debugging element patterns, plugin authors need to keep in mind that the places where element patterns are instantiated are unrelated to where they are actually used.
 For instance, while patterns for completion contributors are instantiated when registering the contributor, the patterns are checked during completion while typing.
-Therefore, finding the correct locations in the _IntelliJ Platform_ for debugging element patterns is the first important step.
+Therefore, finding the correct locations in the IntelliJ Platform for debugging element patterns is the first important step.
 
 However, setting breakpoints inside `ElementPattern` will result in many false-positives since element patterns are used extensively throughout the IDE.
 One way to filter out these false-positives is to use a condition on the breakpoints.

--- a/topics/basics/architectural_overview/general_threading_rules.md
+++ b/topics/basics/architectural_overview/general_threading_rules.md
@@ -4,7 +4,7 @@
 
 ## Read-Write Lock
 
-In general, code-related data structures in the *IntelliJ Platform* are covered by a single reader/writer lock.
+In general, code-related data structures in the IntelliJ Platform are covered by a single reader/writer lock.
 
 You must not access the model outside a read or write action for the following subsystems:
 - [Program Structure Interface](psi.md) (PSI)

--- a/topics/basics/architectural_overview/psi.md
+++ b/topics/basics/architectural_overview/psi.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The Program Structure Interface, commonly referred to as just PSI, is the layer in the _IntelliJ Platform_ responsible for parsing files and creating the syntactic and semantic code model that powers so many of the platform's features.
+The Program Structure Interface, commonly referred to as just PSI, is the layer in the IntelliJ Platform responsible for parsing files and creating the syntactic and semantic code model that powers so many of the platform's features.
 
 * [PSI Files](psi_files.md)
 * [File View Providers](file_view_providers.md)

--- a/topics/basics/architectural_overview/psi_elements.md
+++ b/topics/basics/architectural_overview/psi_elements.md
@@ -6,7 +6,7 @@ A PSI (Program Structure Interface) file represents a hierarchy of PSI elements 
 A single PSI file (itself being a PSI element) may contain several PSI trees in specific programming languages.
 A PSI element, in its turn, can have child PSI elements.
 
-PSI elements and operations at the level of individual PSI elements are used to explore the source code's internal structure as it is interpreted by the **IntelliJ Platform**.
+PSI elements and operations at the level of individual PSI elements are used to explore the source code's internal structure as it is interpreted by the IntelliJ Platform.
 For example, you can use PSI elements to perform code analysis, such as [code inspections](https://www.jetbrains.com/help/idea/code-inspection.html) or [intention actions](https://www.jetbrains.com/idea/help/intention-actions.html).
 
 The [`PsiElement`](upsource:///platform/core-api/src/com/intellij/psi/PsiElement.java) class is the common base class for PSI elements.

--- a/topics/basics/architectural_overview/virtual_file.md
+++ b/topics/basics/architectural_overview/virtual_file.md
@@ -2,10 +2,10 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-A [`VirtualFile`](upsource:///platform/core-api/src/com/intellij/openapi/vfs/VirtualFile.java) (VF) is the *IntelliJ Platform's* representation of a file in a [Virtual File System (VFS)](virtual_file_system.md).
+A [`VirtualFile`](upsource:///platform/core-api/src/com/intellij/openapi/vfs/VirtualFile.java) (VF) is the IntelliJ Platform's representation of a file in a [Virtual File System (VFS)](virtual_file_system.md).
 
 Most commonly, a virtual file is a file in a local file system.
-However, the *IntelliJ Platform* supports multiple pluggable file system implementations, so virtual files can also represent classes in a JAR file, old revisions of files loaded from a version control repository, and so on.
+However, the IntelliJ Platform supports multiple pluggable file system implementations, so virtual files can also represent classes in a JAR file, old revisions of files loaded from a version control repository, and so on.
 
 The VFS level deals only with binary content.
 Contents of a `VirtualFile` are treated as a stream of bytes, but concepts like encodings and line separators are handled on higher system levels.

--- a/topics/basics/basic_action_system.md
+++ b/topics/basics/basic_action_system.md
@@ -367,4 +367,4 @@ To get a Swing component from such an object, call the respective `getComponent(
 If an action toolbar is attached to a specific component (for example, a panel in a tool window), call `ActionToolbar.setTargetComponent()` and pass the related component's instance as a parameter.
 Setting the target ensures that the toolbar buttons' state depends on the state of the related component, not on the current focus location within the IDE frame.
 
-See [Toolbar](https://jetbrains.design/intellij/controls/toolbar/) in _IntelliJ Platform UI Guidelines_ for an overview.
+See [Toolbar](https://jetbrains.design/intellij/controls/toolbar/) in IntelliJ Platform UI Guidelines for an overview.

--- a/topics/basics/basics.md
+++ b/topics/basics/basics.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-This section covers the basics of working with the *IntelliJ Platform*.
+This section covers the basics of working with the IntelliJ Platform.
 It will familiarize you with the working environment, project structure, and frequently used API components.
 
 * [Main Types of IntelliJ Platform Plugins](types_of_plugins.md)

--- a/topics/basics/getting_started.md
+++ b/topics/basics/getting_started.md
@@ -2,10 +2,10 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-This documentation section will help you get started with developing plugins for the *IntelliJ Platform*.
+This documentation section will help you get started with developing plugins for the IntelliJ Platform.
 You can use either [IntelliJ IDEA Community Edition](https://www.jetbrains.com/idea/download/) or [IntelliJ IDEA Ultimate](https://www.jetbrains.com/idea/download/) as your IDE (it is highly recommended to use the latest available version).
 Both include the complete set of plugin development tools.
-To become more familiar with *IntelliJ IDEA*, please refer to the [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/).
+To become more familiar with IntelliJ IDEA, please refer to the [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/).
 
 There are three supported workflows available for building plugins.
 The recommended workflow for new projects is to [use GitHub Template](#using-github-template) or to [use Gradle](#using-gradle) to create everything from scratch.

--- a/topics/basics/getting_started/build_number_ranges.md
+++ b/topics/basics/getting_started/build_number_ranges.md
@@ -16,14 +16,14 @@ The number consists of the following parts:
 * Branch number (`162`)
 * Build number in the branch (`94`)
 
-Since version 2016.2 of the *IntelliJ Platform*, branch numbers are based on the `YYYY.R` [IDE release version numbers](https://blog.jetbrains.com/blog/2016/03/09/jetbrains-toolbox-release-and-versioning-changes/).
+Since version 2016.2 of the IntelliJ Platform, branch numbers are based on the `YYYY.R` [IDE release version numbers](https://blog.jetbrains.com/blog/2016/03/09/jetbrains-toolbox-release-and-versioning-changes/).
 The branch number takes the last two digits of the year and the `R` release number.
 For example, `162` for 2016.2, `163` for 2016.3, `171` for 2017.1.
 In this scheme, `IU-162.94` corresponds to the 2016.2 release.
 
 Starting with 2016.2, the build number may also have multiple components: `IU-162.94`, `IU-162.94.11`, `IU-162.94.11.256.42`.
 This gives more flexibility for third-party plugins and IDE developers.
-Plugins may specify compatibility versions more precisely; IDE vendors may have build numbers based on a specific *IntelliJ Platform* version and specify additional internal version (e.g. `256.42` in `XX-162.94.11.256.42`) to allow plugin developers for their IDE to specify compatibility.
+Plugins may specify compatibility versions more precisely; IDE vendors may have build numbers based on a specific IntelliJ Platform version and specify additional internal version (e.g. `256.42` in `XX-162.94.11.256.42`) to allow plugin developers for their IDE to specify compatibility.
 
 Multi-part build numbers can also be used in the `since-build` and `until-build` attributes of `idea-version`.
 Usually you should omit the product ID and use only the branch number and build number, for example:

--- a/topics/basics/getting_started/creating_plugin_project.md
+++ b/topics/basics/getting_started/creating_plugin_project.md
@@ -8,7 +8,7 @@
 
 This section explains how you can create a new plugin project from scratch using the New Project wizard.
 Optionally, you can import an existing project or import a project from external models.
-You can also add a new plugin module to a current *IntelliJ Platform* project.
+You can also add a new plugin module to a current IntelliJ Platform project.
 For more information, refer to the [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/new-project-wizard.html).
 
 ### To Create an IntelliJ Platform Plugin Project:

--- a/topics/basics/getting_started/plugin_compatibility.md
+++ b/topics/basics/getting_started/plugin_compatibility.md
@@ -3,7 +3,7 @@
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
 ## Introduction
-All products based on the _IntelliJ Platform_ are built on the same underlying API.
+All products based on the IntelliJ Platform are built on the same underlying API.
 Some of these products share features built on top of the platform, such as Java support in IntelliJ IDEA and Android Studio.
 Underlying those shared features are shared components.
 When authoring a plugin for the IntelliJ Platform, it is important to understand and declare dependencies on these components. 
@@ -141,5 +141,5 @@ Based on the tables above, the [JetBrains Plugins Repository](https://plugins.je
 The compatibility information determines if plugins are available at the plugin repository to users of a particular JetBrains product.
 
 ## Platform API Version Compatibility
-The API of _IntelliJ Platform_ and bundled plugins may change between releases.
+The API of IntelliJ Platform and bundled plugins may change between releases.
 The significant changes that may break plugins are listed on [Incompatible Changes in IntelliJ Platform and Plugins API](api_changes_list.md) page.

--- a/topics/basics/getting_started/running_and_debugging_a_plugin.md
+++ b/topics/basics/getting_started/running_and_debugging_a_plugin.md
@@ -2,15 +2,15 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-It's possible to run and debug a plugin directly from the *IntelliJ IDEA*.
+It's possible to run and debug a plugin directly from the IntelliJ IDEA.
 You need a configured special profile (a *Plugin* Run/Debug configuration) that specifies the plugin module, VM parameters, and other specific options.
 When you run such a profile, it launches the IDE with your plugin installed.
 
 See [IDE Development Instances](ide_development_instance.md) for more information about configuration and advanced settings.
 
-For information on how to change the Run/Debug configuration profile, refer to [Run/Debug Configuration](https://www.jetbrains.com/help/idea/run-debug-configuration.html) and [Run/Debug Configuration: Plugin](https://www.jetbrains.com/idea/help/run-debug-configuration-plugin.html) in *IntelliJ IDEA* Web Help.
+For information on how to change the Run/Debug configuration profile, refer to [Run/Debug Configuration](https://www.jetbrains.com/help/idea/run-debug-configuration.html) and [Run/Debug Configuration: Plugin](https://www.jetbrains.com/idea/help/run-debug-configuration-plugin.html) in IntelliJ IDEA Web Help.
 
-Using *IntelliJ IDEA*'s debugger, you can find out the origin of the run-time errors and exceptions.
+Using IntelliJ IDEA's debugger, you can find out the origin of the run-time errors and exceptions.
 
 **To debug a plugin**
 

--- a/topics/basics/indexing_and_psi_stubs/file_based_indexes.md
+++ b/topics/basics/indexing_and_psi_stubs/file_based_indexes.md
@@ -72,7 +72,7 @@ The following primary operations are supported:
 
 ## Standard Indexes
 
-The *IntelliJ Platform* contains several standard file-based indexes.
+The IntelliJ Platform contains several standard file-based indexes.
 The most useful indexes for plugin developers are:
 
 ### Word Index

--- a/topics/basics/persisting_state_of_components.md
+++ b/topics/basics/persisting_state_of_components.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The *IntelliJ Platform* provides an API that allows components or services to persist their state between restarts of the IDE.
+The IntelliJ Platform provides an API that allows components or services to persist their state between restarts of the IDE.
 You can use either a simple API to persist a few values or persist the state of more complicated components using the [`PersistentStateComponent`](upsource:///platform/projectModel-api/src/com/intellij/openapi/components/PersistentStateComponent.java) interface.
 
  >  If you need to persist sensitive data like passwords, please see [Persisting Sensitive Data](persisting_sensitive_data.md).

--- a/topics/basics/plugin_structure/plugin_actions.md
+++ b/topics/basics/plugin_structure/plugin_actions.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The *IntelliJ Platform* provides the concept of _actions_.
+The IntelliJ Platform provides the concept of _actions_.
 An action is a class derived from [`AnAction`](upsource:///platform/editor-ui-api/src/com/intellij/openapi/actionSystem/AnAction.java), whose `actionPerformed()` method is called when its menu item or toolbar button is selected.
 
 Actions are the most common way for a user to invoke the functionality of your plugin.

--- a/topics/basics/plugin_structure/plugin_extensions.md
+++ b/topics/basics/plugin_structure/plugin_extensions.md
@@ -31,7 +31,7 @@ There are [more than 1000 extension](#how-to-get-the-extension-points-list) poin
     * If the extension point was declared using the `interface` attribute, for newly added child element, set the `implementation` attribute to the name of the class that implements the specified interface.
     * If the extension point was declared using the `beanClass` attribute, for newly added child element, set all attributes annotated with the [`@Attribute`](upsource:///platform/util/src/com/intellij/util/xmlb/annotations/Attribute.java) annotations in the specified bean class.
 
-To clarify this procedure, consider the following sample section of the `plugin.xml` file that defines two extensions designed to access the `com.intellij.appStarter` and `com.intellij.projectTemplatesFactory` extension points in the *IntelliJ Platform* and one extension to access the `another.plugin.myExtensionPoint` extension point in another plugin `another.plugin`:
+To clarify this procedure, consider the following sample section of the `plugin.xml` file that defines two extensions designed to access the `com.intellij.appStarter` and `com.intellij.projectTemplatesFactory` extension points in the IntelliJ Platform and one extension to access the `another.plugin.myExtensionPoint` extension point in another plugin `another.plugin`:
 
 ```xml
 <!-- Declare extensions to access extension points in the IntelliJ Platform.
@@ -91,7 +91,7 @@ Attributes with `Enum` type support code insight with _lowerSnakeCased_ notation
 
 ## How to get the extension points list?
 
-[Extension Point List](extension_point_list.md) contains all available in *IntelliJ Platform* and from bundled plugins in IntelliJ IDEA.
+[Extension Point List](extension_point_list.md) contains all available in IntelliJ Platform and from bundled plugins in IntelliJ IDEA.
 
 Alternatively (or when using 3rd party extension points), all available extension points for the specified namespace can be listed using auto-completion inside the `<extensions>` block.
 Use **View \| Quick Documentation** in the lookup list to access more information about the extension point and implementation (if applicable).

--- a/topics/basics/plugin_structure/plugin_services.md
+++ b/topics/basics/plugin_structure/plugin_services.md
@@ -4,7 +4,7 @@
 
 A _service_ is a plugin component loaded on demand when your plugin calls the `getService()` method of [`ServiceManager`](upsource:///platform/core-api/src/com/intellij/openapi/components/ServiceManager.java).
 
-The *IntelliJ Platform* ensures that only one instance of a service is loaded even though it is called several times.
+The IntelliJ Platform ensures that only one instance of a service is loaded even though it is called several times.
 
 A service must have an implementation class that is used for service instantiation.
 A service may also have an interface class used to obtain the service instance and provide the service's API.
@@ -12,7 +12,7 @@ A service may also have an interface class used to obtain the service instance a
 A service needing a shutdown hook/cleanup routine can implement [`Disposable`](upsource:///platform/util/src/com/intellij/openapi/Disposable.java) and perform necessary work in `dispose()` (see [Automatically Disposed Objects](disposers.md#automatically-disposed-objects)).
 
 #### Types
-The *IntelliJ Platform* offers three types of services: _application level_ services (global singleton), _project level_ services, and _module level_ services.
+The IntelliJ Platform offers three types of services: _application level_ services (global singleton), _project level_ services, and _module level_ services.
 For the latter two, a separate instance of the service is created for each instance of its corresponding scope, see [Project Model Introduction](project_structure.md).
 
  >  Please consider not using module-level services because it can increase memory usage for projects with many modules.
@@ -126,6 +126,6 @@ If this number exceeds the maximum number of simultaneously opened projects allo
 **To install and run the sample plugin**
 
 * Download the included sample plugin project located [here](https://github.com/JetBrains/intellij-sdk-code-samples/tree/main/max_opened_projects).
-* Start *IntelliJ IDEA*, on the starting page, click *Open Project*, and then use the *Open Project* dialog box to open the project.
+* Start IntelliJ IDEA, on the starting page, click *Open Project*, and then use the *Open Project* dialog box to open the project.
 * On the main menu, choose *Run \| Run* or press <kbd>Shift</kbd>+<kbd>F10</kbd>.
 * If necessary, change the [Run/Debug Configurations](https://www.jetbrains.com/help/idea/run-debug-configuration-plugin.html).

--- a/topics/basics/run_configurations/run_configuration_execution.md
+++ b/topics/basics/run_configurations/run_configuration_execution.md
@@ -22,7 +22,7 @@ Implementations of `ProgramRunner.execute()` go through the following steps to e
 
 The [`Executor`](upsource:///platform/lang-api/src/com/intellij/execution/Executor.java) interface describes a specific way of executing any possible run configuration.
 
-The three default executors provided by the *IntelliJ Platform* by default are _Run_, _Debug_, and _Run with Coverage_.  Each executor gets its own toolbar button, which starts the selected run configuration using this executor, and its own context menu item for starting a configuration using this executor.
+The three default executors provided by the IntelliJ Platform by default are _Run_, _Debug_, and _Run with Coverage_.  Each executor gets its own toolbar button, which starts the selected run configuration using this executor, and its own context menu item for starting a configuration using this executor.
 
 As a plugin developer, you usually don't need to implement the `Executor` interface.
 However, it can be useful, for example, if you're implementing a profiler integration and want to provide the possibility to execute any configuration with profiling.

--- a/topics/basics/run_configurations/run_configuration_management.md
+++ b/topics/basics/run_configurations/run_configuration_management.md
@@ -68,7 +68,7 @@ That is handled by [`SettingsEditor`](upsource:///platform/platform-api/src/com/
 That run configuration settings are persistent, i.e., they are stored at the file system and loaded back on the IDE startup.
 That is performed via [`writeExternal()`](upsource:///platform/util/src/com/intellij/openapi/util/JDOMExternalizable.java) and [`readExternal()`](upsource:///platform/util/src/com/intellij/openapi/util/JDOMExternalizable.java)<!--#L26--> methods of [`RunConfiguration`](upsource:///platform/lang-api/src/com/intellij/execution/configurations/RunConfiguration.java) class correspondingly.
 
-The actual configurations stored by the *IntelliJ Platform* are represented by instances of the [`RunnerAndConfigurationSettings`](upsource:///platform/lang-api/src/com/intellij/execution/RunnerAndConfigurationSettings.java) class, which combines a run configuration with runner-specific settings, as well as keeping track of certain run configuration flags such as "temporary" or "singleton".
+The actual configurations stored by the IntelliJ Platform are represented by instances of the [`RunnerAndConfigurationSettings`](upsource:///platform/lang-api/src/com/intellij/execution/RunnerAndConfigurationSettings.java) class, which combines a run configuration with runner-specific settings, as well as keeping track of certain run configuration flags such as "temporary" or "singleton".
 
 Dealing with instances of this class becomes necessary when you need to create run configurations from code.
 This is accomplished with the following two steps:

--- a/topics/basics/testing_plugins/light_and_heavy_tests.md
+++ b/topics/basics/testing_plugins/light_and_heavy_tests.md
@@ -2,10 +2,10 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-Plugin tests run in a real, rather than mocked, *IntelliJ Platform* environment and use real implementations for most application and project components/services.
+Plugin tests run in a real, rather than mocked, IntelliJ Platform environment and use real implementations for most application and project components/services.
 
 Loading and initializing all the project components and services for a project to run tests is a relatively expensive operation, and we want to avoid doing it for each test.
-Dependently on the loading and execution time, we make a difference between *heavy* tests and *light* tests available in *IntelliJ Platform* test framework:
+Dependently on the loading and execution time, we make a difference between *heavy* tests and *light* tests available in IntelliJ Platform test framework:
 
 * *Heavy* tests create a new project for each test.
 * *Light* tests reuse a project from the previous test run when possible.

--- a/topics/basics/testing_plugins/test_project_and_testdata_directories.md
+++ b/topics/basics/testing_plugins/test_project_and_testdata_directories.md
@@ -18,9 +18,9 @@ This is just a directory under your plugin's content root, but not under a sourc
 Files in `testdata` usually are not valid source code and must not be compiled.
 
 To specify the location of `testdata`, you must override the `getTestDataPath()` method.
-The default implementation assumes running as part of the *IntelliJ Platform* source tree and is not appropriate for third-party plugins.
+The default implementation assumes running as part of the IntelliJ Platform source tree and is not appropriate for third-party plugins.
 
- >  A very common pattern in *IntelliJ Platform* tests is to use the test method's name being executed as the base for building the `testdata` file paths.
+ >  A very common pattern in IntelliJ Platform tests is to use the test method's name being executed as the base for building the `testdata` file paths.
 > This allows us to reuse most of the code between different test methods that test various aspects of the same feature, and this approach is also recommended for third-party plugin tests.
 > The name of the test method can be retrieved using `UsefulTestCase.getTestName()`.
  >

--- a/topics/basics/testing_plugins/testing_highlighting.md
+++ b/topics/basics/testing_plugins/testing_highlighting.md
@@ -3,7 +3,7 @@
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
 When writing plugin tests, a common task is testing various kinds of highlighting (inspections, annotators, parser error highlighting, etc.).
-The *IntelliJ Platform* provides a dedicated utility and markup format for this task.
+The IntelliJ Platform provides a dedicated utility and markup format for this task.
 
 To test the highlighting for the file currently loaded into the in-memory editor, you invoke the `checkHighlighting()` method.
 The parameters to the method specify which severities should be taken into account when comparing the results with the expected results: errors are always taken into account, whereas warnings, weak warnings, and infos are optional.

--- a/topics/basics/testing_plugins/testing_plugins.md
+++ b/topics/basics/testing_plugins/testing_plugins.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-Most of the tests in the *IntelliJ Platform* codebase are *model level functional tests*.
+Most of the tests in the IntelliJ Platform codebase are *model level functional tests*.
 What this means is the following:
 
 * The tests run in a headless environment that uses real production implementations for most components, except for many UI components.
@@ -19,7 +19,7 @@ Another consequence of our testing approach is what our test framework does not 
 
 * We do not provide a recommended approach to mocking.
   We have a few tests in our codebase that use JMock.
-  Still, in general, we find it difficult to mock all of the interactions with *IntelliJ Platform* components that your plugin class will need to have.
+  Still, in general, we find it difficult to mock all of the interactions with IntelliJ Platform components that your plugin class will need to have.
   We recommend working with real components instead.
 * We do not provide a general-purpose framework for Swing UI testing.
   You can try using tools such as [FEST](https://code.google.com/p/fest/) or [Sikuli](https://sikulix.com/) for plugin UI testing, but we don't use either of them and cannot provide any guidelines for their use.

--- a/topics/basics/testing_plugins/tests_and_fixtures.md
+++ b/topics/basics/testing_plugins/tests_and_fixtures.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The *IntelliJ Platform* testing infrastructure is not tied to any specific test framework.
+The IntelliJ Platform testing infrastructure is not tied to any specific test framework.
 In fact, the IntelliJ IDEA Team uses JUnit, TestNG, and Cucumber for testing different parts of the project.
 However, most of the tests are written using JUnit 3.
 

--- a/topics/basics/types_of_plugins.md
+++ b/topics/basics/types_of_plugins.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-Products based on the *IntelliJ Platform* can be modified and adjusted for custom purposes by adding plugins.
+Products based on the IntelliJ Platform can be modified and adjusted for custom purposes by adding plugins.
 All downloadable plugins are available at the [JetBrains Plugins Repository](https://plugins.jetbrains.com/).
 
 The most common types of plugins include:

--- a/topics/basics/virtual_file_system.md
+++ b/topics/basics/virtual_file_system.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The virtual file system (VFS) is a component of the *IntelliJ Platform* that encapsulates most of its activity for working with files represented as [Virtual File](virtual_file.md).
+The virtual file system (VFS) is a component of the IntelliJ Platform that encapsulates most of its activity for working with files represented as [Virtual File](virtual_file.md).
 
 It serves the following main purposes:
 
@@ -31,19 +31,19 @@ The snapshot is updated from disk during _refresh operations_, which generally h
 All write operations made through the VFS are synchronous - i.e., the contents are saved to disk immediately.
 
 A refresh operation synchronizes the state of a part of the VFS with the actual disk contents.
-Refresh operations are explicitly invoked by the *IntelliJ Platform* or plugin code - i.e., when a file is changed on disk while the IDE is running, the change will not be immediately picked up by the VFS.
+Refresh operations are explicitly invoked by the IntelliJ Platform or plugin code - i.e., when a file is changed on disk while the IDE is running, the change will not be immediately picked up by the VFS.
 The VFS will be updated during the next refresh operation, which includes the file in its scope.
 
-*IntelliJ Platform* refreshes the entire project contents asynchronously on startup.
+IntelliJ Platform refreshes the entire project contents asynchronously on startup.
 By default, it performs a refresh operation when the user switches to it from another app.
 Still, users can turn this off via **Settings \| Appearance & Behavior \| System Settings \| Synchronize external changes \[...]**.
 
-On Windows, Mac, and Linux, a native file watcher process is started that receives file change notifications from the file system and reports them to the *IntelliJ Platform*.
+On Windows, Mac, and Linux, a native file watcher process is started that receives file change notifications from the file system and reports them to the IntelliJ Platform.
 If a file watcher is available, a refresh operation looks only at the files that have been reported as changed by the file watcher.
 If no file watcher is present, a refresh operation walks through all directories and files in the refresh scope.
 
 Refresh operations are based on file timestamps.
-If a file's contents were changed, but its timestamp remained the same, the *IntelliJ Platform* will not pick up the updated contents.
+If a file's contents were changed, but its timestamp remained the same, the IntelliJ Platform will not pick up the updated contents.
 
 There is currently no facility for removing files from the snapshot.
 If a file was loaded there once, it remains there forever unless it was deleted from the disk, and a refresh operation was called on one of its parent directories.

--- a/topics/intro/about.md
+++ b/topics/intro/about.md
@@ -18,13 +18,13 @@ The [Key Topics](key_topics.md) page aims to link to the pages that are necessar
 
 #### [Part I - Plugins](basics.md)
 
-Describes how to create a plugin that can extend the _IntelliJ Platform_.
-Includes details on how to set up the project, register extension points, target specific versions of the _IntelliJ Platform_, and how to package, deploy, and test your plugins.
+Describes how to create a plugin that can extend the IntelliJ Platform.
+Includes details on how to set up the project, register extension points, target specific versions of the IntelliJ Platform, and how to package, deploy, and test your plugins.
 
 #### [Part II - Base Platform](fundamentals.md)
 
 Describes the foundational layer of the architecture, which provides many features and utilities, such as the component model, the user interface, documents and editors, the virtual file system, settings, threading, and background tasks.
-The Base Platform layer mainly comprises the functionality of the _IntelliJ Platform_ that does not target language features or parsing.
+The Base Platform layer mainly comprises the functionality of the IntelliJ Platform that does not target language features or parsing.
 
 #### [Part III - Project Model](project_structure.md)
 
@@ -48,17 +48,17 @@ Describes the available infrastructure for writing automated tests covering the 
 #### [Part VII - Custom Languages](custom_language_support.md)
 
 Plugins frequently extend support for existing languages, such as adding inspections to Java files.
-This section describes how to add support to the _IntelliJ Platform_ for a new language that isn't supported by default, creating parsers, syntactic and semantic models, and all the features that build on top.
+This section describes how to add support to the IntelliJ Platform for a new language that isn't supported by default, creating parsers, syntactic and semantic models, and all the features that build on top.
 
 #### [Part VIII - Product Specific](dev_alternate_products.md)
 
-A lot of the functionality in the _IntelliJ Platform_ is language and product agnostic.
+A lot of the functionality in the IntelliJ Platform is language and product agnostic.
 For example, code inspections work the same in Java as they do in Ruby; it is just the syntax trees and semantic information that is different.
 This section describes product-specific features, such as specific project model differences and how to target them in a plugin.
 
 #### Part IX - Custom IDEs
 
-Documents how to use the _IntelliJ Platform_ to create a new, custom IDE, rather than plugins to an existing product, e.g., WebStorm, or Android Studio.
+Documents how to use the IntelliJ Platform to create a new, custom IDE, rather than plugins to an existing product, e.g., WebStorm, or Android Studio.
 
 #### [Part X - Plugin Repository](plugin_repository_obsolete.md)
 

--- a/topics/intro/intellij_platform.md
+++ b/topics/intro/intellij_platform.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The _IntelliJ Platform_ is not a product in and of itself but provides a platform for building IDEs.
+The IntelliJ Platform is not a product in and of itself but provides a platform for building IDEs.
 It is used to power JetBrains products such as [IntelliJ IDEA](https://www.jetbrains.com/idea/).
 It is also Open Source and can be used by third parties to build IDEs, such as [Android Studio](https://developer.android.com/studio/index.html) from Google.
 

--- a/topics/intro/key_topics.md
+++ b/topics/intro/key_topics.md
@@ -2,14 +2,14 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-The _IntelliJ Platform_ is extensive and very capable, and its size and scope can initially be very daunting.
+The IntelliJ Platform is extensive and very capable, and its size and scope can initially be very daunting.
 This page is intended to list the key topics that a plugin author would be interested in, and provide quick links to the most common extension points.
 
 ## Essential Concepts
 
 - [Creating Your First Plugin](getting_started.md).
 - [Testing plugins](testing_plugins.md).
-- Component model - the _IntelliJ Platform_ is a component-based application and is responsible for creating components and injecting dependencies.
+- Component model - the IntelliJ Platform is a component-based application and is responsible for creating components and injecting dependencies.
   Understanding this is necessary for building plugins.
 - [Extension points](plugin_extensions.md) - how to register components with extension points, and how to find out what extension points are available.
 - [Virtual files](virtual_file.md) - all file access should go through the Virtual File System, which abstracts and caches the file system.
@@ -17,12 +17,12 @@ This page is intended to list the key topics that a plugin author would be inter
 
 ## Code Model
 
-The _IntelliJ Platform_'s code model is called the PSI - the [Program Structure Interface](psi.md).
+The IntelliJ Platform's code model is called the PSI - the [Program Structure Interface](psi.md).
 The PSI parses code, builds indexes, and creates a semantic model.
 
 ## Common Extension Points
 
-The _IntelliJ Platform_ is extremely exceptionally, and most features and services can be extended.
+The IntelliJ Platform is extremely exceptionally, and most features and services can be extended.
 Some of the common extension points are:
 
 * [Actions](action_system.md) - menu and toolbar items

--- a/topics/intro/sdk_style.md
+++ b/topics/intro/sdk_style.md
@@ -10,7 +10,7 @@ First and foremost, we should keep in mind our audience and their objectives:
 _Someone reading technical content is usually looking to answer a specific question.
 That question might be broad or narrowly-focused, but either way, our goal is to provide answers without distraction._
 
-The style of the _Intellij Platform SDK_ documentation is captured by using a markup language named [_Markdown_](https://github.github.com/gfm/).
+The style of the Intellij Platform SDK documentation is captured by using a markup language named [_Markdown_](https://github.github.com/gfm/).
 
 ## Documentation Markup
 
@@ -32,7 +32,7 @@ Redirects can be specified in the [Table of Contents](#table-of-contents).
 
 ### Terminology
 Consistent terminology helps the reader grasp new concepts more quickly:
-* The open-source code in the GitHub repository `intellij-community` is known as the _IntelliJ Platform_.
+* The open-source code in the GitHub repository `intellij-community` is known as the IntelliJ Platform.
   Use the full phrase in the SDK documentation.
 * IDEs based on the IntelliJ Platform are described as _IntelliJ Platform-based IDEs_.
   Once that term is used on a page, authors may use _IDEs_.

--- a/topics/intro/welcome.md
+++ b/topics/intro/welcome.md
@@ -4,7 +4,7 @@
 
 [![official JetBrains project](https://jb.gg/badges/official-flat-square.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub) [![Twitter Follow](https://img.shields.io/twitter/follow/JBPlatform?style=flat-square)](https://twitter.com/JBPlatform/) [![Slack](https://img.shields.io/badge/Slack-%23intellij--platform-blue)](https://plugins.jetbrains.com/slack)
 
-Welcome to the _IntelliJ Platform_ SDK - the primary source of documentation for extending the _IntelliJ Platform_ by creating plugins, custom language support, or building a custom IDE.
+Welcome to the IntelliJ Platform SDK - the primary source of documentation for extending the IntelliJ Platform by creating plugins, custom language support, or building a custom IDE.
 
 ## Getting Started
 

--- a/topics/platform/fundamentals.md
+++ b/topics/platform/fundamentals.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-This section describes the low-level fundamental building blocks of the _IntelliJ Platform_:
+This section describes the low-level fundamental building blocks of the IntelliJ Platform:
 
 * The component model - how the application is hosted and composed. Lifetime and dependency management.
 * [Disposers](disposers.md) - managing object lifetimes and resource cleanup

--- a/topics/reference_guide/custom_language_support.md
+++ b/topics/reference_guide/custom_language_support.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-*IntelliJ Platform* is a powerful platform for building development tools targeting *any* language.
+IntelliJ Platform is a powerful platform for building development tools targeting *any* language.
 Most of the IDE features consist of language-independent (provided by the platform) and language-specific parts.
 Supporting a particular feature for a new language can be achieved with a small amount of effort:
 a plugin must implement only the language-specific part.

--- a/topics/reference_guide/custom_language_support/implementing_parser_and_psi.md
+++ b/topics/reference_guide/custom_language_support/implementing_parser_and_psi.md
@@ -21,7 +21,7 @@ The top-level node of the PSI tree for a file needs to implement the [`PsiFile`]
 
 The PSI's lifecycle is described in more detail in [Fundamentals](fundamentals.md).
 
-The base classes for the PSI implementation, including [`PsiFileBase`](upsource:///platform/core-impl/src/com/intellij/extapi/psi/PsiFileBase.java), the base implementation of [`PsiFile`](upsource:///platform/core-api/src/com/intellij/psi/PsiFile.java), and [`ASTWrapperPsiElement`](upsource:///platform/core-impl/src/com/intellij/extapi/psi/ASTWrapperPsiElement.java), the base implementation of [`PsiElement`](upsource:///platform/core-api/src/com/intellij/psi/PsiElement.java), are provided by *IntelliJ Platform*.
+The base classes for the PSI implementation, including [`PsiFileBase`](upsource:///platform/core-impl/src/com/intellij/extapi/psi/PsiFileBase.java), the base implementation of [`PsiFile`](upsource:///platform/core-api/src/com/intellij/psi/PsiFile.java), and [`ASTWrapperPsiElement`](upsource:///platform/core-impl/src/com/intellij/extapi/psi/ASTWrapperPsiElement.java), the base implementation of [`PsiElement`](upsource:///platform/core-api/src/com/intellij/psi/PsiElement.java), are provided by IntelliJ Platform.
 
 While coding parser manually is quite possible, we highly recommend generating parser and corresponding PSI classes from grammars using [Grammar-Kit](https://plugins.jetbrains.com/plugin/6606-grammar-kit) plugin.
 Besides code generation, it provides various features for editing grammar files: syntax highlighting, quick navigation, refactorings, etc.

--- a/topics/reference_guide/custom_language_support/structure_view.md
+++ b/topics/reference_guide/custom_language_support/structure_view.md
@@ -4,7 +4,7 @@
 
 The Structure View implementation used for a specific file type can be customized on many levels.
 If a custom language plugin provides an implementation of the [`StructureView`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/StructureView.java) interface, it can completely replace the standard structure view implementation with a custom user interface component.
-However, for most languages, this is not necessary, and the standard [`StructureView`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/StructureView.java) implementation provided by *IntelliJ Platform* can be reused.
+However, for most languages, this is not necessary, and the standard [`StructureView`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/StructureView.java) implementation provided by IntelliJ Platform can be reused.
 
 The starting point for the structure view is the [`PsiStructureViewFactory`](upsource:///platform/editor-ui-api/src/com/intellij/lang/PsiStructureViewFactory.java) interface, which is registered in the `com.intellij.lang.psiStructureViewFactory` extension point.
 
@@ -12,7 +12,7 @@ The starting point for the structure view is the [`PsiStructureViewFactory`](ups
 - [`PsiStructureViewFactory`](upsource:///plugins/properties/src/com/intellij/lang/properties/structureView/PropertiesStructureViewBuilderFactory.java) for [Properties language plugin](upsource:///plugins/properties)
 - [Custom Language Support Tutorial: Structure View](structure_view_factory.md)
 
-To reuse the *IntelliJ Platform* implementation of the [`StructureView`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/StructureView.java), the plugin returns a [`TreeBasedStructureViewBuilder`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/TreeBasedStructureViewBuilder.java) from its [`PsiStructureViewFactory.getStructureViewBuilder()`](upsource:///platform/editor-ui-api/src/com/intellij/lang/PsiStructureViewFactory.java) method.
+To reuse the IntelliJ Platform implementation of the [`StructureView`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/StructureView.java), the plugin returns a [`TreeBasedStructureViewBuilder`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/TreeBasedStructureViewBuilder.java) from its [`PsiStructureViewFactory.getStructureViewBuilder()`](upsource:///platform/editor-ui-api/src/com/intellij/lang/PsiStructureViewFactory.java) method.
 As the builder model, the plugin can specify a subclass of [`TextEditorBasedStructureViewModel`](upsource:///platform/editor-ui-api/src/com/intellij/ide/structureView/TextEditorBasedStructureViewModel.java), and by overriding methods of this subclass, it customizes the structure view for a specific language.
 
 **Example**:

--- a/topics/reference_guide/custom_language_support/syntax_highlighting_and_error_highlighting.md
+++ b/topics/reference_guide/custom_language_support/syntax_highlighting_and_error_highlighting.md
@@ -61,7 +61,7 @@ When the file is changed, the annotator is called incrementally to process only 
  {type="note"}
 
 ### Errors/Warning
-See [Inspections](https://jetbrains.design/intellij/text/inspections/) topic in _IntelliJ Platform UI Guidelines_ on how to write message texts for highlighting/quick fixes.
+See [Inspections](https://jetbrains.design/intellij/text/inspections/) topic in IntelliJ Platform UI Guidelines on how to write message texts for highlighting/quick fixes.
 
 To highlight a region of text as a warning or error (2020.1 and later):
 ```java

--- a/topics/reference_guide/messaging_infrastructure.md
+++ b/topics/reference_guide/messaging_infrastructure.md
@@ -107,13 +107,13 @@ public void doChange(Context context) {
 
 * *MessageBus* instances are available via [`ComponentManager.getMessageBus()`](upsource:///platform/extensions/src/com/intellij/openapi/components/ComponentManager.java)
   Many standard interfaces implement a message bus, e.g., [`Application`](upsource:///platform/core-api/src/com/intellij/openapi/application/Application.java) and [`Project`](upsource:///platform/core-api/src/com/intellij/openapi/project/Project.java).
-* A number of public topics are used by the *IntelliJ Platform*, e.g., [`AppTopics`](upsource:///platform/platform-api/src/com/intellij/AppTopics.java), [`ProjectTopics`](upsource:///platform/projectModel-api/src/com/intellij/ProjectTopics.java), etc.
+* A number of public topics are used by the IntelliJ Platform, e.g., [`AppTopics`](upsource:///platform/platform-api/src/com/intellij/AppTopics.java), [`ProjectTopics`](upsource:///platform/projectModel-api/src/com/intellij/ProjectTopics.java), etc.
   So, it's possible to subscribe to them in order to receive information about the processing;
 
 ## Broadcasting
 
 Message buses can be organised into hierarchies.
-Moreover, the *IntelliJ Platform* has them already:
+Moreover, the IntelliJ Platform has them already:
 
 ![Standard hierarchy](standard_hierarchy.svg)
 

--- a/topics/reference_guide/project_model/module.md
+++ b/topics/reference_guide/project_model/module.md
@@ -22,7 +22,7 @@ The key components of a module are:
 In addition to that, a module can store other settings, such as a module-specific [SDK](sdk.md), compile output path settings, etc.
 Plugins can store additional data associated with a module by creating facets or module-level components.
 
-The *IntelliJ Platform* provides a number of classes and interfaces you can use to work with modules:
+The IntelliJ Platform provides a number of classes and interfaces you can use to work with modules:
 
 * [`Module`](upsource:///platform/core-api/src/com/intellij/openapi/module/Module.java)
 * [`ModuleUtil`](upsource:///platform/lang-api/src/com/intellij/openapi/module/ModuleUtil.java)
@@ -41,7 +41,7 @@ Use the `ModuleManager.getModules()` method.
 ### How do I get dependencies and classpath of a module?
 
 _Order entries_ include SDK, libraries and other modules the module uses.
-With the *IntelliJ IDEA* UI, you can view order entries for a module on the [Dependencies](https://www.jetbrains.com/help/idea/dependencies-tab.html) tab of the *Project Structure* dialog box.
+With the IntelliJ IDEA UI, you can view order entries for a module on the [Dependencies](https://www.jetbrains.com/help/idea/dependencies-tab.html) tab of the *Project Structure* dialog box.
 
 To explore the [module dependencies](https://www.jetbrains.com/help/idea/dependencies-tab.html), use the [`OrderEnumerator`](upsource:///platform/projectModel-api/src/com/intellij/openapi/roots/OrderEnumerator.java) class.
 

--- a/topics/reference_guide/project_model/project.md
+++ b/topics/reference_guide/project_model/project.md
@@ -2,14 +2,14 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-In the *IntelliJ Platform*, a project encapsulates all the source code, libraries, and build instructions into a single organizational unit.
+In the IntelliJ Platform, a project encapsulates all the source code, libraries, and build instructions into a single organizational unit.
 Everything done in the IDE is accomplished within the context of a project.
 A project defines some collections referred to as modules and libraries.
 Depending on the logical and functional requirements for the project, a single-module or a multi-module project is possible.
 
 ## Working with Projects
 
-The *IntelliJ Platform* stores the project configuration data in XML files.
+The IntelliJ Platform stores the project configuration data in XML files.
 The list of those files depends on the chosen [project](https://www.jetbrains.com/help/idea/about-projects.html) format.
 
 For file-based format projects (legacy), the information core to the project itself (e.g., location of the component modules, compiler settings, etc.) is stored in the `%project_name%.ipr` file.

--- a/topics/reference_guide/ui_themes/themes_customize.md
+++ b/topics/reference_guide/ui_themes/themes_customize.md
@@ -132,7 +132,7 @@ The color of a replaced icon takes precedence over any `ColorPalette` overrides.
 UI Themes can change the appearance of more general controls in the IntelliJ Platform UI.
 Examples of these controls are labels, buttons, checkboxes, trees, lists, and menus.
 
-See also [Platform theme colors — UI components](https://jetbrains.design/intellij/principles/platform_theme_colors/#UI-components) in _IntelliJ Platform UI Guidelines_.                      
+See also [Platform theme colors — UI components](https://jetbrains.design/intellij/principles/platform_theme_colors/#UI-components) in IntelliJ Platform UI Guidelines.                      
 
 ### Custom UI Control Colors
 A UI control's custom color is specified by adding a key-value pair to the `"ui": {}` section of a Theme description file.

--- a/topics/tutorials/build_system/gradle_guide.md
+++ b/topics/tutorials/build_system/gradle_guide.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-This page serves as a guide to Gradle-based plugin configuration for _IntelliJ Platform_ projects.
+This page serves as a guide to Gradle-based plugin configuration for IntelliJ Platform projects.
 The IntelliJ IDEA Ultimate and Community editions bundle the _Gradle_ and _Plugin DevKit_ plugins to support Gradle-based development.
 
 The [Getting Started with Gradle](gradle_prerequisites.md) page provides a tutorial for creating Gradle-based IntelliJ Platform plugins.

--- a/topics/tutorials/code_inspections.md
+++ b/topics/tutorials/code_inspections.md
@@ -10,7 +10,7 @@ In addition, the comparing_references_inspection code sample demonstrates implem
 You can also create custom inspections through the IntelliJ IDEA user interface.
 See [Code Inspection](https://www.jetbrains.com/idea/webhelp/code-inspection.html) and [Creating Custom Inspections](https://www.jetbrains.com/idea/help/creating-custom-inspections.html) for more information.
                      
-See [Inspections](https://jetbrains.design/intellij/text/inspections/) topic in _IntelliJ Platform UI Guidelines_ on naming, writing description, and message texts for inspections.
+See [Inspections](https://jetbrains.design/intellij/text/inspections/) topic in the IntelliJ Platform UI Guidelines on naming, writing description, and message texts for inspections.
 
 ## Creating an Inspection Plugin
 
@@ -146,7 +146,7 @@ The [comparing_references_inspection](https://github.com/JetBrains/intellij-sdk-
 The inspection reports when the `==` or `!=` operator is used between Java expressions of reference types.
 
 To run the sample plugin:
-* Start **IntelliJ IDEA**, open the `intellij-sdk-docs` project, and highlight the [comparing_references_inspection](https://github.com/JetBrains/intellij-sdk-code-samples/tree/main/comparing_references_inspection) module.
+* Start IntelliJ IDEA, open the `intellij-sdk-docs` project, and highlight the [comparing_references_inspection](https://github.com/JetBrains/intellij-sdk-code-samples/tree/main/comparing_references_inspection) module.
 * Open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog and ensure that the project settings are valid for your environment.
 * If necessary, modify the [Run/Debug Configurations](https://www.jetbrains.com/idea/webhelp/run-debug-configuration-plugin.html) for the `comparing_references_inspection` module.
 * Run the plugin by choosing **Run** on the main menu.

--- a/topics/tutorials/code_intentions.md
+++ b/topics/tutorials/code_intentions.md
@@ -7,16 +7,16 @@ In addition, the sample plugin contains a JUnit-based test.
 
 ## About Intention Actions
 
-The **IntelliJ Platform** analyzes your code and helps handle situations that may result in errors.
+The IntelliJ Platform analyzes your code and helps handle situations that may result in errors.
 When a possible problem is suspected, the IDE suggests an appropriate intention action, denoted with special icons.
-For more information, refer to [Intention Actions](https://www.jetbrains.com/help/idea/intention-actions.html) in the **IntelliJ IDEA** Web Help.
+For more information, refer to [Intention Actions](https://www.jetbrains.com/help/idea/intention-actions.html) in the IntelliJ IDEA Web Help.
 
 You can view a list of all available intention actions using the [Intention List](https://www.jetbrains.com/help/idea/intention-actions.html#intention-settings) provided by the IDE.
 
 **To display Intention List**
 
 1. Open the **Settings** dialog box.
-2. Under **IDE Settings**, click **Intentions**. This displays the list of all intention actions currently available in **IntelliJ IDEA**.
+2. Under **IDE Settings**, click **Intentions**. This displays the list of all intention actions currently available in IntelliJ IDEA.
 - The intention actions are grouped according to the areas of their use.
 - To enable/disable an intention action, select/deselect the check box to its left.
 
@@ -40,14 +40,14 @@ When launched, this plugin adds the **Convert ternary operator if statement** it
 
 **To run the sample plugin**
 
-1. Start **IntelliJ IDEA** and open the **conditionalOperatorConvertor** plugin project saved into the `<%IntelliJ SDK Docs project%>/code_samples/conditional_operator_intention` directory.
+1. Start IntelliJ IDEA and open the **conditionalOperatorConvertor** plugin project saved into the `<%IntelliJ SDK Docs project%>/code_samples/conditional_operator_intention` directory.
 2. Open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog and ensure that the project settings are valid for your environment.
 3. If necessary, modify the [Run/Debug Configurations](https://www.jetbrains.com/idea/webhelp/run-debug-configuration-plugin.html) and Run the plugin by choosing the **Run** on the main menu.
 
 #### How does it work?
 
 The plugin analyzes symbols under the cursor in your code opened in the IDEA editor.
-If the cursor is positioned on the "?" conditional operator, **IntelliJ IDEA** proposes to replace this conditional (ternary) operator with the "if-then-else" statement:
+If the cursor is positioned on the "?" conditional operator, IntelliJ IDEA proposes to replace this conditional (ternary) operator with the "if-then-else" statement:
 
 ![](TernaryOperator.png)
 
@@ -75,4 +75,4 @@ if ((n>=0)) {
 The sample plugin contains the `ConditionalOperatorConverterTest` Java class and the test data in the `test/testData/` directory.
 To perform the plugin test, run the `ConditionalOperatorConverterTest.testIntention()` method.
 
-For detailed information about testing and all related procedures, refer to [Testing](https://www.jetbrains.com/help/idea/performing-tests.html) in the **IntelliJ IDEA** Web Help.
+For detailed information about testing and all related procedures, refer to [Testing](https://www.jetbrains.com/help/idea/performing-tests.html) in the IntelliJ IDEA Web Help.

--- a/topics/tutorials/project_wizard/adding_new_steps.md
+++ b/topics/tutorials/project_wizard/adding_new_steps.md
@@ -81,7 +81,7 @@ public class DemoModuleWizardStep extends ModuleBuilder {
 ```
 
 ## Checking UI Appearance
-After compiling and running the plugin, create a new project using a source-compiled instance of *IntelliJ IDEA*.
+After compiling and running the plugin, create a new project using a source-compiled instance of IntelliJ IDEA.
 
 ![New Project](empty_project.png)
 

--- a/topics/tutorials/project_wizard/module_types.md
+++ b/topics/tutorials/project_wizard/module_types.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-*IntelliJ Platform* provides a set of standard module types.
+IntelliJ Platform provides a set of standard module types.
 However, an application might need module of a type that isn't supported yet.
 This tutorial shows how to register a new module type and link it to the project creation procedure and the UI.
            

--- a/topics/tutorials/run_configurations.md
+++ b/topics/tutorials/run_configurations.md
@@ -3,7 +3,7 @@
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
 These series of steps show how to register and implement a simple Run Configuration.
-Run Configurations are used to run internal and external processes from within *IntelliJ Platform* based products.
+Run Configurations are used to run internal and external processes from within IntelliJ Platform based products.
 To get familiar with the concept of a Run Configuration refer [Run/Debug Configuration](https://www.jetbrains.com/idea/help/run-debug-configuration.html) section of  [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/intellij-idea.html)
 
 ## Pre-Requirements

--- a/topics/user_interface_components/dialog_wrapper.md
+++ b/topics/user_interface_components/dialog_wrapper.md
@@ -4,7 +4,7 @@
 
 ## DialogWrapper
 
-The [`DialogWrapper`](upsource:///platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java) is the base class which is supposed to be used for all modal dialogs (and some non-modal dialogs) shown in *IntelliJ Platform*.
+The [`DialogWrapper`](upsource:///platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java) is the base class which is supposed to be used for all modal dialogs (and some non-modal dialogs) shown in IntelliJ Platform.
 
 It provides the following features:
 

--- a/topics/user_interface_components/editor_components.md
+++ b/topics/user_interface_components/editor_components.md
@@ -4,7 +4,7 @@
 
 ## EditorTextField
 
-Compared to [Swing `JTextArea`](https://docs.oracle.com/javase/8/docs/api/javax/swing/JTextArea.html), the *IntelliJ Platform's* editor component has a ton of advantages: syntax highlighting support, code completion, code folding and much more.
+Compared to [Swing `JTextArea`](https://docs.oracle.com/javase/8/docs/api/javax/swing/JTextArea.html), the IntelliJ Platform's editor component has a ton of advantages: syntax highlighting support, code completion, code folding and much more.
 Editors are normally displayed in editor tabs, but they can be embedded in dialogs or tool windows, too.
 This is enabled by the [`EditorTextField`](upsource:///platform/platform-impl/src/com/intellij/ui/EditorTextField.java) component.
 

--- a/topics/user_interface_components/file_and_class_choosers.md
+++ b/topics/user_interface_components/file_and_class_choosers.md
@@ -15,7 +15,7 @@ The constructor parameters specify whether files and/or directories can be selec
 
 For more fine-grained control over the allowed selection, you can overload the `isFileSelectable()` method.
 You can also customize the presentation of files by overriding `getIcon()`, `getName()` and `getComment()` methods.
-Note that the native macOS file chooser does not support most of the customizations, so if you rely on them, you need to use an overload of `chooseFiles()` which displays the standard *IntelliJ Platform* dialog.
+Note that the native macOS file chooser does not support most of the customizations, so if you rely on them, you need to use an overload of `chooseFiles()` which displays the standard IntelliJ Platform dialog.
 
 ### Via Textfield
 

--- a/topics/user_interface_components/misc_swing_components.md
+++ b/topics/user_interface_components/misc_swing_components.md
@@ -31,6 +31,6 @@ It has a significantly different look & feel compared to the standard Swing tabs
 
 ### Toolbars
 
-See [Toolbar](https://jetbrains.design/intellij/controls/toolbar/) in _IntelliJ Platform UI Guidelines_ for an overview.
+See [Toolbar](https://jetbrains.design/intellij/controls/toolbar/) in the IntelliJ Platform UI Guidelines for an overview.
 
 [Building UI from Actions](basic_action_system.md#building-ui-from-actions) covers creating `AnAction`-based toolbars.

--- a/topics/user_interface_components/notifications.md
+++ b/topics/user_interface_components/notifications.md
@@ -2,9 +2,9 @@
 
 <!-- Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
-One of the leading design principles is avoiding the use of modal message boxes for notifying the user about errors and other situations that may warrant the user's attention. As a replacement, the *IntelliJ Platform* provides multiple non-modal notification UI options.
+One of the leading design principles is avoiding the use of modal message boxes for notifying the user about errors and other situations that may warrant the user's attention. As a replacement, the IntelliJ Platform provides multiple non-modal notification UI options.
 
-For an overview, refer to [Notifications](https://jetbrains.design/intellij/controls/notifications/) in _IntelliJ Platform UI Guidelines_.
+For an overview, refer to [Notifications](https://jetbrains.design/intellij/controls/notifications/) in IntelliJ Platform UI Guidelines.
 
 ### Dialogs
 
@@ -24,7 +24,7 @@ It has two main advantages:
 * The user can control the way each notification type is displayed under `Settings | Appearance & Behavior | Notifications`
 * All displayed notifications are gathered in the Event Log tool window and can be reviewed later
          
-For UI reference, see [Balloon](https://jetbrains.design/intellij/controls/balloon/) in _IntelliJ Platform UI Guidelines_.
+For UI reference, see [Balloon](https://jetbrains.design/intellij/controls/balloon/) in the IntelliJ Platform UI Guidelines.
 
 The specific method used to display a notification is [`Notifications.Bus.notify()`](upsource:///platform/platform-api/src/com/intellij/notification/Notifications.java). If the current Project is known, please use overload with `Project` parameter, so the notification is shown in its associated frame.
 

--- a/topics/user_interface_components/popups.md
+++ b/topics/user_interface_components/popups.md
@@ -4,7 +4,7 @@
 
 ## Popups
 
-The *IntelliJ Platform* user interface makes extensive use of popups \- semi-modal windows that have no chrome (explicit closing buttons) and disappear automatically on focus loss.
+The IntelliJ Platform user interface makes extensive use of popups \- semi-modal windows that have no chrome (explicit closing buttons) and disappear automatically on focus loss.
 Making use of these controls in your plugin ensures a consistent user experience between your plugin and the rest of the IDE.
 
 Popups can optionally display a title, are optionally movable and resizable (and support remembering their size), and can be nested (show another popup when an item is selected).

--- a/topics/user_interface_components/tool_windows.md
+++ b/topics/user_interface_components/tool_windows.md
@@ -6,7 +6,7 @@
 
 _Tool windows_ are child windows of the IDE used to display information.
 These windows generally have their own toolbars (referred to as _tool window bars_) along the outer edges of the main window containing one or more _tool window buttons_, which activate panels displayed on the left, bottom and right sides of the main IDE window.
-For detailed information about tool windows, please see [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/tool-windows.html) and [Tool window](https://jetbrains.design/intellij/components/tool_window/) topic in _IntelliJ Platform UI Guidelines_.
+For detailed information about tool windows, please see [IntelliJ IDEA Web Help](https://www.jetbrains.com/idea/help/tool-windows.html) and [Tool window](https://jetbrains.design/intellij/components/tool_window/) topic in IntelliJ Platform UI Guidelines.
 
 Each side contains two tool window groups, the primary and the secondary one, and only one tool window from each group can be active at a time.
 
@@ -69,7 +69,7 @@ This plugin creates the **Sample Calendar** tool window that displays the system
 
 **To run the toolWindow plugin**
 
-1. Start **IntelliJ IDEA** and open the **tool_window** project saved into the [code_samples/tool_window](https://github.com/JetBrains/intellij-sdk-code-samples/tree/main/tool_window) directory.
+1. Start IntelliJ IDEA and open the **tool_window** project saved into the [code_samples/tool_window](https://github.com/JetBrains/intellij-sdk-code-samples/tree/main/tool_window) directory.
 2. Ensure that the project settings are valid for the environment.
    If necessary, modify the project settings.
    To view or modify the project settings, open the [Project Structure](https://www.jetbrains.com/help/idea/project-structure-dialog.html) dialog.

--- a/topics/user_interface_components/user_interface_components.md
+++ b/topics/user_interface_components/user_interface_components.md
@@ -14,7 +14,7 @@ Using those components in your plugins will ensure that your plugin looks and wo
  >
  {type="note"}
 
-Please refer to [Writing short and clear](https://jetbrains.design/intellij/text/writing_short/) in _IntelliJ Platform UI Guidelines_ on writing UI-related texts.
+Please refer to [Writing short and clear](https://jetbrains.design/intellij/text/writing_short/) in IntelliJ Platform UI Guidelines on writing UI-related texts.
 
 The following components are particularly noteworthy:
 


### PR DESCRIPTION
I styled all usages of "IntelliJ Platform" (and "IntelliJ Platform UI Guidelines") consistently without _italics_ or **boldness**. The reason for that is two-fold: First, right now we have no consistency at all, and usages differ in styling often on the same page. The second reasoning was given in a discussion:

> I vote for removing the italics from the term in all places: It's already capitalized which makes it stand out and using italics just adds visual noise that we should reserve for other more important places. Also, the whole docs are about the IntelliJ Platform and it's like emphasizing Tomato in a tomato-recipe. Finally, to make it consistent, we had to make it italic in all the headers where it's used which would look awful.

However, when you say something like

- IDEs based on the IntelliJ Platform are described as _IntelliJ Platform-based IDEs_.
- In the _Additional Libraries and Frameworks_ panel, select _Java_ and _IntelliJ Platform Plugin_.

It is absolutely OK (and even required) to make it stand out. In fact, that's exactly the use-case for which we should reserve the styling.