### PR TITLE
Added a page with a short tutorial for the projectSdkSetupValidator EP.

### DIFF
--- a/topics/intro/content_updates.md
+++ b/topics/intro/content_updates.md
@@ -16,6 +16,9 @@ Element Patterns
 Editor - Text Selection
 : Add a new section about [Text Selection EPs](text_selection.md) and describe [`ExtendWordSelectionHandler`](upsource:///platform/lang-api/src/com/intellij/codeInsight/editorActions/ExtendWordSelectionHandler.java)
 
+SDK Setup Assistance
+: Added a code sample to the SDK tutorial that expands on assisting in the setup of an SDK
+
 ## 2020
                   
 ### December-20


### PR DESCRIPTION
Added a quick code tutorial in a sub-page to the "Assisting in Setting Up an SDK" section to help new plugin developers (like me) to quickly get running with this great EP. I formatted the files/links according to the code style guidelines so hopefully everything should be formatted correctly.