### PR TITLE
Update run configuration tutorial with newer APIs

### DIFF
--- a/code_samples/run_configuration/src/main/java/org/jetbrains/sdk/runConfiguration/DemoRunConfigurationType.java
+++ b/code_samples/run_configuration/src/main/java/org/jetbrains/sdk/runConfiguration/DemoRunConfigurationType.java
@@ -2,40 +2,17 @@
 
 package org.jetbrains.sdk.runConfiguration;
 
-import com.intellij.execution.configurations.ConfigurationFactory;
-import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.icons.AllIcons;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.openapi.util.NotNullLazyValue;
 
-import javax.swing.*;
-
-public class DemoRunConfigurationType implements ConfigurationType {
-
-  @NotNull
-  @Override
-  public String getDisplayName() {
-    return "Demo";
+public class DemoRunConfigurationType extends ConfigurationTypeBase {
+  protected DemoRunConfigurationType() {
+    super("DemoRunConfiguration",
+            "Demo",
+            "Demo run configuration type",
+            NotNullLazyValue.createValue(() -> AllIcons.General.Information)
+    );
+    addFactory(new DemoConfigurationFactory(this));
   }
-
-  @Override
-  public String getConfigurationTypeDescription() {
-    return "Demo run configuration type";
-  }
-
-  @Override
-  public Icon getIcon() {
-    return AllIcons.General.Information;
-  }
-
-  @NotNull
-  @Override
-  public String getId() {
-    return "DEMO_RUN_CONFIGURATION";
-  }
-
-  @Override
-  public ConfigurationFactory[] getConfigurationFactories() {
-    return new ConfigurationFactory[]{new DemoConfigurationFactory(this)};
-  }
-
 }

--- a/topics/intro/content_updates.md
+++ b/topics/intro/content_updates.md
@@ -19,6 +19,9 @@ Editor - Text Selection
 SDK Setup Assistance
 : Added a code sample to the SDK tutorial that expands on [assisting in the setup of an SDK](sdk.md#assisting-in-setting-up-an-sdk).
 
+Run Configurations
+: Updated the [run configuration tutorial](run_configurations.md#implement-configurationtype) to show usages of the newer APIs available in the IntelliJ Platform SDK.
+
 ## 2020
                   
 ### December-20

--- a/topics/reference_guide/project_model/sdk.md
+++ b/topics/reference_guide/project_model/sdk.md
@@ -102,7 +102,7 @@ class DemoProjectSdkSetupValidator : ProjectSdkSetupValidator {
 Within `DemoProjectSdkSetupValidator`:
 
 - `isApplicableFor()` checks what condition(s) should be met to run the validation.
-- `getErrorMessage()` runs the validation and return an appropriate error message if the validation fails. If the validation is successful, then it should return null.
+- `getErrorMessage()` runs the validation and returns an appropriate error message if the validation fails. If the validation is successful, then it should return null.
 - `getFixHandler()` returns an `EditorNotificationPanel.ActionHandler` that enables the user to execute a quick-fix to resolve the validation issue.
 
 


### PR DESCRIPTION
The run configuration tutorial currently shows the usage of very old interfaces even though much newer, cleaner interfaces are now available in the IntelliJ API. I updated the code samples to show the usage of the new APIs and left a note in there about the "original" way to do it by implementing `ConfigurationType`.

I have also updated the code samples to use one of the newer APIs and tested that it's working correctly:
![image](https://user-images.githubusercontent.com/6986426/111883501-33124d00-8992-11eb-94f8-e83d1e2b6a61.png)

I noticed that there is pretty much no documentation for the classes in `runConfigurationType.kt`. Do we want to add something there? (I can write up another gist for that if so)