### PR TITLE
Add API breaks in 2021

### DIFF
--- a/reference_guide/api_changes_list_2021.md
+++ b/reference_guide/api_changes_list_2021.md
@@ -154,3 +154,8 @@ JSON Widget suppressor EP `com.intellij.json.jsonWidgetSuppressor`
 
 Rename of packages to `.java.` specific variants
 : A number of packages have been renamed: `com.intellij.uml.utils` becomes `com.intellij.uml.java.utils`, `com.intellij.uml.project` becomes `com.intellij.uml.java.project`, and `com.intellij.uml.jigsaw` becomes `com.intellij.uml.java.jigsaw`.
+
+### Kotlin Plugin 2021.1
+
+`org.jetbrains.kotlin.idea.refactoring.changeSignature.KotlinChangeInfo(KotlinMethodDescriptor, String, KotlinTypeInfo, Visibility, List, KotlinParameterInfo, PsiElement, Collection)` constructor parameter type changed from `org.jetbrains.kotlin.descriptors.Visibility` to `org.jetbrains.kotlin.descriptors.DescriptorVisibility`
+: The compiler change


### PR DESCRIPTION
Add API breaks in 2021 caused by https://github.com/JetBrains/intellij-community/commit/981d27937b7f1704fbfb975fac2a86e0fc60462a#diff-7ccfef9fbfab7e55b92f0ef8dc1e287f9e29d666a57bd14724c8173aa570e0d4L60