### PR TITLE
Document inner classes removal

### DIFF
--- a/reference_guide/api_changes_list_2021.md
+++ b/reference_guide/api_changes_list_2021.md
@@ -94,6 +94,14 @@ Please see [Incompatible API Changes](api_changes_list.md) on how to verify comp
 `com.intellij.ide.plugins.DisabledPluginsState.disablePlugin(PluginId)` method removed
 : Use either `com.intellij.ide.plugins.PluginManagerCore.disablePlugin(PluginId)` or `com.intellij.ide.plugins.PluginEnabler.disablePlugins(Collection)` instead.
 
+`com.intellij.ssh.ui.unified.SshConfigConfigurable.Visibility` class removed
+: Use `com.intellij.ssh.ui.unified.SshConfigVisibility` instead.
+
+### Database Plugin 2021.2
+
+`com.intellij.database.dataSource.DatabaseCredentialsAuthProvider.UserWidget` class removed
+: Use `com.intellij.database.dataSource.DatabaseCredentialsAuthProviderUi.UserWidget` instead.
+
 ### GitHub Plugin 2021.2
                                           
 `org.jetbrains.plugins.github.util.GithubAuthData` class removed


### PR DESCRIPTION
The classes were extracted in order to decouple the logic from the UI.