### PR TITLE
gradle_prerequisites.md: Remove note on incompatible generated build.gradle

### DIFF
--- a/topics/tutorials/build_system/gradle_prerequisites.md
+++ b/topics/tutorials/build_system/gradle_prerequisites.md
@@ -96,12 +96,7 @@ my_gradle_plugin
   If needed, the IntelliJ IDEA Gradle plugin downloads the version of Gradle specified in this file.
 * The <path>settings.gradle</path> file, containing a definition of the `rootProject.name`.
 * The <path>META-INF</path> directory under the default `main` [SourceSet](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_project_layout) contains the plugin [configuration file](plugin_configuration_file.md).
-                                                 
- > Please note: the generated <path>build.gradle</path> file needs to be adjusted as shown below, as IntelliJ IDEA currently generates template incompatible with gradle-intellij-plugin 1.0 release.   
- > See [Upgrade Instructions](https://lp.jetbrains.com/gradle-intellij-plugin/) for more details.
- > 
- {type="warning"}
- 
+
 The generated `my_gradle_plugin` project <path>build.gradle</path> file:
 
 ```groovy


### PR DESCRIPTION
# What
"note on incompatible generated build.gradle" can be removed, because this issue has been resolved.
ref: https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+2021.1.3+(211.7628.21+build)+Release+Notes

Or should the note be leaved for users using older IntelliJ versions?