### PR TITLE
Update project.ihp

### DIFF
--- a/project.ihp
+++ b/project.ihp
@@ -9,6 +9,7 @@
     <module name="intellij-sdk"/>
     <topics src="topics"/>
     <topics src="reference_guide"/>
+    <topics src="."/>
     <images dir="images" web-path="/img/idea-sdk/"/>
 
     <snippets src="code_samples"/>


### PR DESCRIPTION
This will keep files located on the same level as project.ihp available in build because we've recently updated help builder so that it won't automatically touch these files (some other projects are storing notes and remarks with exact file names as their topic files in this root, so we need to differentiate.)