### PR TITLE
Document incompatibilities

### DIFF
--- a/reference_guide/api_changes_list_2021.md
+++ b/reference_guide/api_changes_list_2021.md
@@ -75,6 +75,18 @@ Please see [Incompatible API Changes](api_changes_list.md) on how to verify comp
                               
 ### Changes in IntelliJ Platform 2021.3
 
+`com.intellij.ui.mac.MacMessages.showMessageDialog(String, String, String[], boolean, Window, int, int, DialogWrapper.DoNotAskOption) : int` method removed
+: Use `com.intellij.ui.mac.MacMessages.showMessageDialog(String, String, String[], boolean, Window, int, int,  DoNotAskOption) : int` instead
+
+`com.intellij.openapi.ui.MessageDialogBuilder.doNotAsk(DialogWrapper.DoNotAskOption)` method removed
+: Use `com.intellij.openapi.ui.MessageDialogBuilder.doNotAsk(DoNotAskOption)` instead
+
+`com.intellij.ide.util.projectWizard.WizardContext.getWizard() : AbstractWizard` method removed
+: Use `ccom.intellij.ide.util.projectWizard.WizardContext.getUserData(AbstractWizard.KEY)` instead
+
+`com.intellij.openapi.ui.TextComponentAccessor.TEXT_FIELD_WITH_HISTORY_WHOLE_TEXT : TextComponentAccessor` field removed
+: Use `com.intellij.openapi.ui.TextComponentAccessors.TEXT_FIELD_WITH_HISTORY_WHOLE_TEXT` instead
+
 `com.intellij.execution.process.ColoredOutputTypeRegistry.getAnsiColorKey(int)` method removed
 : Use `com.intellij.execution.process.ColoredOutputTypeRegistryImpl.getAnsiColorKey(int)` instead
 


### PR DESCRIPTION
During the decoupling of ide.core and ide.core.impl modules from platform.ide and platofrm.ide.impl there were some incompatible changes that couldn't be avoided.
The main reason for it was that there were dependency on the UI sepcific implementations in the API, which in general should be avoided.