### PR TITLE
update "kotlin for plugin developers" page

### DIFF
--- a/topics/tutorials/kotlin.md
+++ b/topics/tutorials/kotlin.md
@@ -111,7 +111,7 @@ Depending on exact functionality, a plugin can also target [UAST (Unified Abstra
 
 ## Caution
 
-Plugins *must* use [Kotlin classes](https://kotlinlang.org/docs/classes.html) to implement declarations in the [plugin configuration file](plugin_configuration_file.md).
+Plugins *may* use [Kotlin classes](https://kotlinlang.org/docs/classes.html) to implement declarations in the [plugin configuration file](plugin_configuration_file.md).
 When registering an extension, the platform uses a dependency injection framework to instantiate these classes.
 For this reason, plugins *must not* use [Kotlin objects](https://kotlinlang.org/docs/object-declarations.html) to implement any <path>plugin.xml</path> declarations.
 


### PR DESCRIPTION
"Plugins must use Kotlin classes" looks confusing for me, like it's forbidden to use Java classes.