### PR TITLE
Update api_changes_list_2022.md: removed JSch

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -90,3 +90,6 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 `com.intellij.psi.impl.java.stubs.index.JavaFullClassNameIndex.get(Integer, Project, GlobalSearchScope)` method parameter type changed from `Integer` to `CharSequence`
 : `JavaFullClassNameIndex` now takes `CharSequence` instead of its `hashCode` to allow specific optimizations
 
+<!-- https://youtrack.jetbrains.com/issue/MP-4136 -->
+JSch was removed from the core
+: Add [com.jcraft:jsch:0.1.55](https://mvnrepository.com/artifact/com.jcraft/jsch/0.1.55) as a dependency explicitly.


### PR DESCRIPTION
The rationale behind the change is to remove the library which is not used in the platform any more. On the first hand, the change is easily avoidable. We can keep delivering the library, which consumes less than 300 KiB. On the other hand, it is easy to add that library as a dependency on the side of plugins, and new versions of plugins are expected to work with older IDE versions.