### PR TITLE
Feature documentation (aka QuickDoc in the Features section)

### DIFF
--- a/ijs.tree
+++ b/ijs.tree
@@ -197,7 +197,7 @@
                     <toc-element id="using_file_templates.md"/>
                 </toc-element>
             </toc-element>
-            <toc-element toc-title="QuickDoc"/>
+            <toc-element id="code_documentation.md"/>
             <toc-element id="code_intentions.md" toc-title="Intentions"/>
         </toc-element>
         <toc-element id="analyzing.md" toc-title="Analysing">

--- a/topics/tutorials/code_documentation.md
+++ b/topics/tutorials/code_documentation.md
@@ -3,7 +3,7 @@
 <!-- Copyright 2000-2022 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 
 [Quick Documentation](https://www.jetbrains.com/help/idea/viewing-reference-information.html#inline-quick-documentation)
-helps users by showing documentation for symbols like method calls inside the editor.
+helps users by showing documentation, e.g., for classes, functions, or methods inside the editor.
 Plugin authors implement
 [`DocumentationProvider`](upsource:///platform/analysis-api/src/com/intellij/lang/documentation/DocumentationProvider.java)
 to show documentation for particular Psi elements.
@@ -11,5 +11,23 @@ to show documentation for particular Psi elements.
 `DocumentationProvider` can be used for existing languages as well as for a custom language implementation.
 For an existing language, the implementation of `DocumentationProvider` is registered as `com.intellij.documentationProvider` extension point (EP),
 while custom languages should register it as `com.intellij.lang.documentationProvider` EP.
-For details on how to implement a `DocumentationProvider`, please refer to the [Custom Language Support](documentation_provider.md)
+The difference between both is that the latter requires the `language` attribute when registering the EP in the `plugin.xml` and is only called
+for this particular language.
+
+Several documentation providers can co-exist for the same language, and plugin authors can implement additional ones even for languages not under
+their control.
+If there is more than one provider for the same element, then the first one that returns a value different from `null` wins.
+Although discouraged, the ordering of documentation providers can be influenced by using the `order` attribute when registering the extension.
+For instance, [`python-core-common.xml`](upsource:///python/src/META-INF/python-core-common.xml) uses the following to call the external documentation
+provider before the default one:
+
+```xml
+<lang.documentationProvider
+  language="Python"
+  implementationClass="com.jetbrains.python.documentation.PythonExternalDocumentationProvider"
+  order="before pythonDocumentationProvider"
+/>
+```
+
+For detailed instructions on how to implement a `DocumentationProvider`, please refer to the [Custom Language Support](documentation_provider.md)
 section and the descriptions in the [Custom Language Support Tutorial](documentation.md).

--- a/topics/tutorials/code_documentation.md
+++ b/topics/tutorials/code_documentation.md
@@ -1,0 +1,15 @@
+[//]: # (title: Documentation)
+
+<!-- Copyright 2000-2022 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+
+[Quick Documentation](https://www.jetbrains.com/help/idea/viewing-reference-information.html#inline-quick-documentation)
+helps users by showing documentation for symbols like method calls inside the editor.
+Plugin authors implement
+[`DocumentationProvider`](upsource:///platform/analysis-api/src/com/intellij/lang/documentation/DocumentationProvider.java)
+to show documentation for particular Psi elements.
+
+`DocumentationProvider` can be used for existing languages as well as for a custom language implementation.
+For an existing language, the implementation of `DocumentationProvider` is registered as `com.intellij.documentationProvider` extension point (EP),
+while custom languages should register it as `com.intellij.lang.documentationProvider` EP.
+For details on how to implement a `DocumentationProvider`, please refer to the [Custom Language Support](documentation_provider.md)
+section and the descriptions in the [Custom Language Support Tutorial](documentation.md).

--- a/topics/tutorials/code_documentation.md
+++ b/topics/tutorials/code_documentation.md
@@ -6,17 +6,16 @@
 helps users by showing documentation, e.g., for classes, functions, or methods inside the editor.
 Plugin authors implement
 [`DocumentationProvider`](upsource:///platform/analysis-api/src/com/intellij/lang/documentation/DocumentationProvider.java)
-to show documentation for particular Psi elements.
+to show documentation for particular PSI elements.
 
-`DocumentationProvider` can be used for existing languages as well as for a custom language implementation.
-For an existing language, the implementation of `DocumentationProvider` is registered as `com.intellij.documentationProvider` extension point (EP),
-while custom languages should register it as `com.intellij.lang.documentationProvider` EP.
-The difference between both is that the latter requires the `language` attribute when registering the EP in the `plugin.xml` and is only called
-for this particular language.
+Implementations of `DocumentationProvider` can be registered either at the `com.intellij.documentationProvider` or the
+`com.intellij.lang.documentationProvider` extension point (EP).
+It is recommended to use the latter one when creating documentation that targets a specific language because providers registered
+as `com.intellij.lang.documentationProvider` will only be called for elements from that language.
+This is the reason they require the `language` attribute when registering the EP in the <path>plugin.xml</path>.
+The bigger picture here is that documentation providers co-exist and if there is more than one provider for the same element,
+the first one that returns a value different from `null` wins.
 
-Several documentation providers can co-exist for the same language, and plugin authors can implement additional ones even for languages not under
-their control.
-If there is more than one provider for the same element, then the first one that returns a value different from `null` wins.
 Although discouraged, the ordering of documentation providers can be influenced by using the `order` attribute when registering the extension.
 For instance, [`python-core-common.xml`](upsource:///python/src/META-INF/python-core-common.xml) uses the following to call the external documentation
 provider before the default one:
@@ -25,9 +24,10 @@ provider before the default one:
 <lang.documentationProvider
   language="Python"
   implementationClass="com.jetbrains.python.documentation.PythonExternalDocumentationProvider"
-  order="before pythonDocumentationProvider"
-/>
+  order="before pythonDocumentationProvider"/>
 ```
 
 For detailed instructions on how to implement a `DocumentationProvider`, please refer to the [Custom Language Support](documentation_provider.md)
 section and the descriptions in the [Custom Language Support Tutorial](documentation.md).
+
+  implementationClass="com.jetbrains.python.documentation.PythonExternalDoc


### PR DESCRIPTION
A small section as a general overview for `DocumenationProvider` that explains some high-level stuff and refers to the article in the Custom Language Support section.