### PR TITLE
Document DataGrip API breakage

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -140,4 +140,10 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 : `GridDataRequest` is a part of new API for async loading of table data. It's not possible to keep old method with default implementation because `DataProducer` will no longer have dependency on `DataRequest`. Plugins need to be recompiled to maintain bytecode compatibility.
 
 `com.intellij.database.datagrid.DataRequest.RawQueryRequest.afterLastRowAdded(DataRequest.Context, int)` method parameter type changed from `DataRequest.Context` to `GridDataRequest.Context`
-: The signature of the method was changed in the interface `com.intellij.database.datagrid.DataConsumer` that is now a part of new API for async loading of table data. Change the type of overriden method and recompile plugin to maintain bytecode compatibility.
+: The signature of the method was changed in the interface `com.intellij.database.datagrid.DataConsumer` that is now a part of new API for async loading of table data. Change the parameter type of overriden the method and recompile plugin to maintain bytecode compatibility.
+
+`com.intellij.database.datagrid.DataConsumer#addRows(DataRequest.Context, List<DataConsumer.Row>)` method parameter type changed from `DataRequest.Context` to `GridDataRequest.Context`
+: The signature of the method was changed in the interface `com.intellij.database.datagrid.DataConsumer` that is now a part of new API for async loading of table data. Change the perameter type of the overriden method and recompile plugin to maintain bytecode compatibility.
+
+`com.intellij.database.datagrid.DataConsumer#addRows(DataRequest.Context, List<DataConsumer.Row>)` method parameter type changed from `List<DataConsumer.Row>` to `List<? extends GridRow>`
+: The signature of the method was changed in the interface `com.intellij.database.datagrid.DataConsumer` that is now a part of new API for async loading of table data. Change the perameter type of the overriden method and recompile plugin to maintain bytecode compatibility.


### PR DESCRIPTION
The breakage affects one plugin https://plugins.jetbrains.com/plugin/13913-sql-server-backup-and-restore/
I plan to make a PR with a fix to the plugin before 2022.2 release