### PR TITLE
welcome.md: contributing to platform

### DIFF
--- a/topics/intro/welcome.md
+++ b/topics/intro/welcome.md
@@ -63,5 +63,8 @@ Verify your plugin follows guidelines from [Dynamic Plugins](dynamic_plugins.md)
 
 ## Contribute
 
+The platform, (most of) IntelliJ IDEA Community Edition, (most of) PyCharm Community Edition, and the Python and reStructuredText plugins for IntelliJ IDEA Community Edition are Open Source, mostly licensed under Apache 2.0. (N.B. JetBrains may bundle some closed-source plugins with their releases of IntelliJ IDEA/PyCharm Community Edition.)
+[Contributions](platform_contributions.md) are welcome.
+
 This guide is Open Source and licensed under Apache 2.0.
 [Contributions](intellij-sdk-docs-original_CONTRIBUTING.md) are very welcome.


### PR DESCRIPTION
Make it easier to find the docs on contributing to the actual software.

I may have overdone it a bit, but I think it's at least accurate.

I write "mostly licensed under Apache 2.0" because there are at least some files under the Eclipse Public License in there -- mostly PyDev, but maybe a few others.

I would probably have linked to https://www.jetbrains.com/legal/community-bundled-plugins/ if I had found it before committing. (I still might.)