### PR TITLE
Document API breakages in Database Tools and SQL Plugin

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -190,3 +190,6 @@ Method `com.intellij.grazie.GrazieBundle.message(key, parameters)` marked static
 
 `com.intellij.database.datagrid.DataConsumer.addRows(DataRequest.Context, List<DataConsumer.Row>)` method parameter type changed from `List<DataConsumer.Row>` to `List<? extends GridRow>`
 : The signature of the method was changed in the interface `com.intellij.database.datagrid.DataConsumer` that is now a part of new API for async loading of table data. Change the parameter type of the overridden method and recompile plugin to maintain bytecode compatibility.
+
+`com.intellij.database.extractors.ObjectFormatter.getPlainValue(Object, DataConsumer.Column, Dbms)` method removed
+: Method was removed because we refactor table editor API. It will not depend on Dbms anymore. Please use `ObjectFormatter.objectToString` instead.


### PR DESCRIPTION
It will break compatibility of one plugin https://plugins.jetbrains.com/plugin/13886-copy-as-sql
I plan to write an email to the author of plugin because it's not open source.

The change is mandatory because we want other teams to reuse our tables thus we need to get rid of dependency on `Dbms`.