### PR TITLE
Document API breakages in Database Tools and SQL Plugin

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -193,3 +193,9 @@ Method `com.intellij.grazie.GrazieBundle.message(key, parameters)` marked static
 
 `com.intellij.database.extractors.ObjectFormatter.getPlainValue(Object, DataConsumer.Column, Dbms)` method removed
 : Method was removed because we refactor table editor API. It will not depend on Dbms anymore. Please use `ObjectFormatter.objectToString` instead.
+
+`com.intellij.database.DatabaseDataKeys.DATA_SOURCE_KEY` field removed
+: `DatabaseDataKeys` no longer extends `DatabaseDataKeysCore` because `DatabaseDataKeys` was moved to a separate module for table editor. `DATA_SOURCE_KEY` now has to be accessed directly via `DatabaseDataKeysCore`.
+
+`com.intellij.database.extractors.ObjectFormatter` class now interface
+: Method was removed because we refactor table editor API. New API will allow to use table editor in other products and fully customize it.


### PR DESCRIPTION
Both changes break only one small plugin https://plugins.jetbrains.com/plugin/13886-copy-as-sql
As already mentioned in #775 I plan to write to plugin's author