### PR TITLE
Use the correct wording

### DIFF
--- a/topics/tutorials/custom_language_support/formatter.md
+++ b/topics/tutorials/custom_language_support/formatter.md
@@ -36,7 +36,7 @@ foo = bar
 ```
 </compare>
 
-Create `SimpleFormattingModelBuilder` by subclassing [`FormattingModelBuilder`](upsource:///platform/code-style-api/src/com/intellij/formatting/FormattingModelBuilder.java).
+Create `SimpleFormattingModelBuilder` by implementing [`FormattingModelBuilder`](upsource:///platform/code-style-api/src/com/intellij/formatting/FormattingModelBuilder.java).
 
 ```java
 ```


### PR DESCRIPTION
`SimpleFormattingModelBuilder` implements `FormattingModelBuilder` and does not subclassing it.