### PR TITLE
Fix code samples in "Language Injection" article

### DIFF
--- a/topics/reference_guide/custom_language_support/language_injection.md
+++ b/topics/reference_guide/custom_language_support/language_injection.md
@@ -291,8 +291,19 @@ class MyDsl { void foo() { System.out.println(42); } }
 Here, we need to inject Java into several places at once, i.e. method name and its body:
 
 ```java
+package org.intellij.sdk.language;
+
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
 public class MyBizarreDSLInjector implements MultiHostInjector {
 
+  // ...
+
+  @Override
   public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar,
                                    @NotNull PsiElement context) {
     if (isMethodTag(context)) {

--- a/topics/reference_guide/custom_language_support/language_injection.md
+++ b/topics/reference_guide/custom_language_support/language_injection.md
@@ -225,7 +225,7 @@ The method `performInjection()` does the actual injection into the context PSI e
 [`MultiHostInjector`](upsource:///platform/core-api/src/com/intellij/lang/injection/MultiHostInjector.java) registered in `com.intellij.multiHostInjector` EP is a very low-level API, but it gives plugin authors the most freedom.
 It performs language injection inside other PSI elements, e.g. inject SQL inside an XML tag text or inject regular expressions into Java string literals.
 
-Plugin authors need to implement `getLanguagesToInject()` to provide a list of places to inject a language to and `elementsToInjectIn()` to return a list of elements to inject into.
+Plugin authors need to implement `getLanguagesToInject()` to provide a list of places to inject a language, and `elementsToInjectIn()` to return a list of elements to inject.
 
 For example, inject regular expressions into Java string literal:
 
@@ -261,6 +261,13 @@ public class MyRegExpToJavaInjector implements MultiHostInjector {
     return List.of(PsiLiteralExpression.class);
   }
 }
+```
+
+Register the implementation in your <path>plugin.xml</path>:
+
+```xml
+<multiHostInjector
+    implementation="org.intellij.sdk.language.MyRegExpToJavaInjector"/>
 ```
 
 A more complex example is when you need to inject into several fragments at once.

--- a/topics/reference_guide/custom_language_support/language_injection.md
+++ b/topics/reference_guide/custom_language_support/language_injection.md
@@ -172,10 +172,12 @@ public final class MyInjector implements LanguageInjectionContributor {
     if (!isConfigPlace(context)) return null;
     if (shouldInjectYaml(context)) {
       return new SimpleInjection(
-          YAMLLanguage.INSTANCE.getID(), "", "", null);
+          YAMLLanguage.INSTANCE, "", "", null
+      );
     } else if (shouldInjectJSON(context)) {
       return new SimpleInjection(
-          JsonLanguage.INSTANCE.getID(), "", "", null);
+          JsonLanguage.INSTANCE, "", "", null
+      );
     }
     return null;
   }
@@ -221,7 +223,8 @@ public class MyRegExpToJavaInjector implements MultiHostInjector {
     if (context instanceof PsiLiteralExpression && shouldInject(context)) {
       registrar
         .startInjecting(REGEXP_LANG)
-        .addPlace(null, null, context, innerRangeStrippingQuotes(context));
+        .addPlace(null, null, context, innerRangeStrippingQuotes(context))
+        .doneInjecting();
     }
   }
 }

--- a/topics/reference_guide/custom_language_support/language_injection.md
+++ b/topics/reference_guide/custom_language_support/language_injection.md
@@ -166,19 +166,7 @@ As a plugin author, implement [`LanguageInjectionContributor`](upsource:///platf
 For instance, if you want to inject a YAML or JSON to a literal language depending on some conditions, you could implement this interface like this:
 
 ```java
-package org.intellij.sdk.language;
-
-import com.intellij.json.JsonLanguage;
-import com.intellij.lang.injection.general.Injection;
-import com.intellij.lang.injection.general.LanguageInjectionContributor;
-import com.intellij.lang.injection.general.SimpleInjection;
-import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 public final class MyInjector implements LanguageInjectionContributor {
-
-  // ...
 
   @Override
   public @Nullable Injection getInjection(@NotNull PsiElement context) {
@@ -201,7 +189,7 @@ Register the implementation in your <path>plugin.xml</path>:
 
 ```xml
 <languageInjectionContributor
-    implementationClass="org.intellij.sdk.language.MyInjector"
+    implementationClass="MyInjector"
     language="YourLanguage"/>
 ```
 
@@ -230,20 +218,7 @@ Plugin authors need to implement `getLanguagesToInject()` to provide a list of p
 For example, inject regular expressions into Java string literal:
 
 ```java
-package org.intellij.sdk.language;
-
-import com.intellij.lang.injection.MultiHostInjector;
-import com.intellij.lang.injection.MultiHostRegistrar;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiLiteralExpression;
-import org.intellij.lang.regexp.RegExpLanguage;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-
 public class MyRegExpToJavaInjector implements MultiHostInjector {
-
-  // ...
 
   @Override
   public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar,
@@ -267,7 +242,7 @@ Register the implementation in your <path>plugin.xml</path>:
 
 ```xml
 <multiHostInjector
-    implementation="org.intellij.sdk.language.MyRegExpToJavaInjector"/>
+    implementation="MyRegExpToJavaInjector"/>
 ```
 
 A more complex example is when you need to inject into several fragments at once.
@@ -291,17 +266,7 @@ class MyDsl { void foo() { System.out.println(42); } }
 Here, we need to inject Java into several places at once, i.e. method name and its body:
 
 ```java
-package org.intellij.sdk.language;
-
-import com.intellij.lang.injection.MultiHostInjector;
-import com.intellij.lang.injection.MultiHostRegistrar;
-import com.intellij.lang.java.JavaLanguage;
-import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-
 public class MyBizarreDSLInjector implements MultiHostInjector {
-
-  // ...
 
   @Override
   public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar,


### PR DESCRIPTION
- `SimpleInjection` now takes `Language` as first parameter, not `String`.
- `doneInjecting()` should be called at the end of injecting.
- Fixed link to `RegExpLanguage`.
- Added information about the `MultiHostInjector.elementsToInjectIn()` method, which also needs to be implemented.
- Added `plugin.xml` example in `MultiHostInjector` for consistency.