### PR TITLE
Update API changes in 222.2 for Webpack

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -161,6 +161,20 @@ Method `com.intellij.grazie.GrazieBundle.message(key, parameters)` marked static
 `com.intellij.docker.registry.DockerRegistry` class renamed to `com.intellij.docker.registry.DockerRegistryConfiguration`
 : Please update usages.
 
+### JavaScript Plugin 2022.2
+
+`com.intellij.lang.javascript.buildTools.webpack.WebPackConfigManager.setConfig(WebPackConfig)` method moved to the superclass
+: Should be used only in tests, marked with @TestOnly directive.
+
+`com.intellij.lang.javascript.buildTools.webpack.WebPackConfig` class renamed to `com.intellij.lang.javascript.buildTools.bundler.WebBundlerConfig`
+: Use `com.intellij.lang.javascript.buildTools.bundler.WebBundlerConfig` instead.
+
+`com.intellij.lang.javascript.buildTools.webpack.WebPackResolve` class renamed to `com.intellij.lang.javascript.buildTools.bundler.WebBundlerResolve`
+: Use `com.intellij.lang.javascript.buildTools.bundler.WebBundlerResolve` instead.
+
+`com.intellij.lang.javascript.buildTools.webpack.WebPackConfigPath` class removed
+: A regular String class is used instead.
+
 ## 2022.1
 
 ### IntelliJ Platform 2022.1


### PR DESCRIPTION
Because of new [support](https://youtrack.jetbrains.com/issue/WEB-55332/Vite-aliases-in-viteconfig-support) for Vite bundler, an existing Webpack API was significantly reworked.

When I worked on those changes, there were no usages, and a tremendous amount of work is already spent on it, so there is no possible way to revert it. Also, it looks like a single plugin that depends on that API uses a `@TestOnly` method (`com.intellij.lang.javascript.buildTools.webpack.WebPackConfigManager.setConfig(WebPackConfig)`), and it's not actually expected.

Also, note that in 223 Webpack and Vite will be moved entirely to separate plugins.