### PR TITLE
Update welcome.md

### DIFF
--- a/topics/intro/welcome.md
+++ b/topics/intro/welcome.md
@@ -2,7 +2,7 @@
 
 <!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
 
-[![official JetBrains project](https://jb.gg/badges/official-flat-square.svg)](https://github.com/JetBrains/.github/blob/main/profile/README.md) [![Twitter Follow](https://img.shields.io/twitter/follow/JBPlatform?style=flat-square&logo=twitter)](https://twitter.com/JBPlatform/) [![Slack](https://img.shields.io/badge/Slack-%23intellij--platform-blue?style=flat-square&logo=slack)](https://plugins.jetbrains.com/slack)
+[![official JetBrains project](https://jb.gg/badges/official-flat-square.svg){type="joined"}](https://github.com/JetBrains/.github/blob/main/profile/README.md) [![Twitter Follow](https://img.shields.io/twitter/follow/JBPlatform?style=flat-square&logo=twitter){type="joined"}](https://twitter.com/JBPlatform/) [![Slack](https://img.shields.io/badge/Slack-%23intellij--platform-blue?style=flat-square&logo=slack){type="joined"}](https://plugins.jetbrains.com/slack)
 
 Welcome to the IntelliJ Platform SDK – the primary source of documentation for extending the IntelliJ Platform by creating plugins, custom language support, or building a custom IDE.
 


### PR DESCRIPTION
Earlier we only had inline images in links, so it was possible to assign proper styles to images that are used in this way; now we've implemented banners that are block images that can also be found in links. Now the image type must be explicitly specified, which is what I did here.