### PR TITLE
Android Studio plugin documentation - runIde should be inside tasks block

### DIFF
--- a/topics/products/androidstudio/android_studio.md
+++ b/topics/products/androidstudio/android_studio.md
@@ -76,10 +76,12 @@ intellij {
   plugins.set(listOf("android"))
 }
 
-runIde {
-  // Absolute path to installed target 3.5 Android Studio to use as
-  // IDE Development Instance (the "Contents" directory is macOS specific):
-  ideDir.set(file("/Applications/Android Studio.app/Contents"))
+tasks {
+  runIde {
+    // Absolute path to installed target 3.5 Android Studio to use as
+    // IDE Development Instance (the "Contents" directory is macOS specific):
+    ideDir.set(file("/Applications/Android Studio.app/Contents"))
+  }
 }
 ```
 
@@ -100,11 +102,13 @@ intellij {
   plugins = ['android']
 }
 
-runIde {
-  // Absolute path to installed target 3.5 Android Studio to use as
-  // IDE Development Instance (the "Contents" directory is macOS specific):
-  ideDir = file('/Applications/Android Studio.app/Contents')
-}
+tasks {
+  runIde {
+    // Absolute path to installed target 3.5 Android Studio to use as
+    // IDE Development Instance (the "Contents" directory is macOS specific):
+    ideDir = file('/Applications/Android Studio.app/Contents')
+  }
+}  
 ```
 
 </tab>

--- a/topics/products/androidstudio/android_studio.md
+++ b/topics/products/androidstudio/android_studio.md
@@ -102,13 +102,11 @@ intellij {
   plugins = ['android']
 }
 
-tasks {
-  runIde {
-    // Absolute path to installed target 3.5 Android Studio to use as
-    // IDE Development Instance (the "Contents" directory is macOS specific):
-    ideDir = file('/Applications/Android Studio.app/Contents')
-  }
-}  
+runIde {
+  // Absolute path to installed target 3.5 Android Studio to use as
+  // IDE Development Instance (the "Contents" directory is macOS specific):
+  ideDir = file('/Applications/Android Studio.app/Contents')
+}
 ```
 
 </tab>


### PR DESCRIPTION
The `runIde` has to be inside the `tasks` block to work properly. This info was not captured in the documentation. So added that now.