### PR TITLE
Specify breaking change about UrlPathInlayAction for 2022.3

### DIFF
--- a/reference_guide/api_changes_list_2022.md
+++ b/reference_guide/api_changes_list_2022.md
@@ -161,6 +161,12 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 `com.intellij.lang.javascript.buildTools.webpack.WebPackConfigManager.Companion` class moved to package `com.intellij.webpack`
 : Use `com.intellij.webpack.WebpackConfigManager.Companion` instead.
 
+### Microservices Plugin 2022.3
+
+`com.intellij.microservices.url.inlay.UrlPathInlayAction.isAvailable(file: PsiFile, urlPathContext: UrlPathContext)` method parameter type changed from `com.intellij.microservices.url.references.UrlPathContext`
+to `com.intellij.microservices.url.inlay.UrlPathInlayHint`.
+: Use `com.intellij.microservices.url.inlay.UrlPathInlayHint.getContext` to obtain corresponding `UrlPathContext` instance.
+
 ## 2022.2
 
 ### IntelliJ Platform 2022.2

--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -83,9 +83,3 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 <include src="tools_gradle_intellij_plugin.md" include-id="gradle_plugin_223_problem"></include>
 
 ### IntelliJ Platform 2023.1
-
-### Microservices Plugin 2023.1
-
-`com.intellij.microservices.url.inlay.UrlPathInlayAction.isAvailable(file: PsiFile, urlPathContext: UrlPathContext)` method parameter type changed from `com.intellij.microservices.url.references.UrlPathContext`
-to `com.intellij.microservices.url.inlay.UrlPathInlayHint`.
-: Use `com.intellij.microservices.url.inlay.UrlPathInlayHint.getContext` to obtain corresponding `UrlPathContext` instance.


### PR DESCRIPTION
Previously I described the change for 2023.1 by mistake