### PR TITLE
Add SimpleNode.doUpdate() method removal

### DIFF
--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -70,6 +70,9 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 
 ### IntelliJ Platform 2023.1
 
+`com.intellij.ui.treeStructure.SimpleNode.doUpdate()` method removed
+: It was replaced by `doUpdate(PresentationData)` which should now only modify the state of its parameter.
+
 `com.intellij.openapi.externalSystem.view.ExternalSystemNode.setNameAndTooltip(String, String)` method removed
 : The new `setNameAndTooltip(PresentationData, String, String)` overload should be used instead.
 


### PR DESCRIPTION
As a part of IDEA-307083 (Rework PresentableNodeDescriptor/SimpleNode update logic), it was needed to move away from doUpdate() modifying the object's state directly, so a new parameter was needed.