### PR TITLE
Document API change in HighLevelHostAccessor

### DIFF
--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -111,3 +111,8 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 
 `org.jetbrains.wip.WipVm.ready()` method return type changed from `void` to `org.jetbrains.concurrency.Promise<*>`
 : `ready()` is now awaitable to make WIP/CDP connection-dependent initialization logic possible.
+
+### JetBrains Gateway Plugin 2023.1
+
+`com.jetbrains.gateway.ssh.HighLevelHostAccessor.isPathPresentOnRemote(string, FileSystemItem)` method parameter type changed from `string` to `com.jetbrains.gateway.ssh.deploy.RemotePath`
+: Using strings instead of paths breaks a lot of things when doing cross-platform development, and is generally not a good idea. Use `com.jetbrains.gateway.ssh.HighLevelHostAccessor.makeRemotePath` to prepare a path to pass into any of the methods requiring it.


### PR DESCRIPTION
Moving on from strings in favor of `RemotePath` structure.