### PR TITLE
GitHub Actions: Replace set-output with GitHub Environment Files

### DIFF
--- a/.github/workflows/code-samples.yml
+++ b/.github/workflows/code-samples.yml
@@ -64,8 +64,8 @@ jobs:
         id: properties
         shell: bash
         run: |
-          echo "::set-output name=ideVersions::${PLUGIN_VERIFIER_IDE_VERSIONS// /-}"
-          echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
+          echo "ideVersions=${PLUGIN_VERIFIER_IDE_VERSIONS// /-}" >> $GITHUB_OUTPUT
+          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
 
       - name: Run Plugin Verifier
         run: |


### PR DESCRIPTION
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/