### PR TITLE
Add Run IDE with Plugin configuration to all plugin samples.

### DIFF
--- a/code_samples/action_basics/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/action_basics/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/comparing_string_references_inspection/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/comparing_string_references_inspection/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/conditional_operator_intention/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/conditional_operator_intention/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/editor_basics/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/editor_basics/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/facet_basics/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/facet_basics/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/framework_basics/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/framework_basics/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/kotlin_demo/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/kotlin_demo/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/live_templates/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/live_templates/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/max_opened_projects/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/max_opened_projects/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/module/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/module/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/project_model/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/project_model/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/project_view_pane/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/project_view_pane/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/project_wizard/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/project_wizard/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/psi_demo/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/psi_demo/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/run_configuration/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/run_configuration/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/settings/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/settings/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/simple_language_plugin/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/simple_language_plugin/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/tool_window/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/tool_window/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/code_samples/tree_structure_provider/.run/Run IDE with Plugin.run.xml
+++ b/code_samples/tree_structure_provider/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value=""/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2"/>
+    </configuration>
+</component>


### PR DESCRIPTION
This run configuration by default creates when you create plugin in intellij idea. It's easier to run sample, if there is run ide configuration 