### PR TITLE
Mention JUnit4 and JUnit5 variants of LightJavaCodeInsightFixtureTestCase

### DIFF
--- a/topics/appendix/api_notable/api_notable_list_2022.md
+++ b/topics/appendix/api_notable/api_notable_list_2022.md
@@ -64,3 +64,8 @@ Unbundled plugins
 
 Published Maven Test Framework
 : Available as `com.jetbrains.intellij.maven:maven-test-framework` from [](intellij_artifacts.md).
+
+### Java Plugin 2022.1
+
+Testframework: JUnit5 variant for `LightJavaCodeInsightFixtureTestCase`
+: Use [`LightJavaCodeInsightFixtureTestCase5`](%gh-ic%/java/testFramework/src/com/intellij/testFramework/fixtures/LightJavaCodeInsightFixtureTestCase5.kt).

--- a/topics/basics/testing_plugins/light_and_heavy_tests.md
+++ b/topics/basics/testing_plugins/light_and_heavy_tests.md
@@ -26,6 +26,8 @@ The standard way of writing a light test is to extend the following classes:
   For plugins using pre-2019.2 versions use [`LightPlatformCodeInsightFixtureTestCase`](%gh-ic%/platform/testFramework/src/com/intellij/testFramework/fixtures/LightPlatformCodeInsightFixtureTestCase.java).
 * [`LightJavaCodeInsightFixtureTestCase`](%gh-ic%/java/testFramework/src/com/intellij/testFramework/fixtures/LightJavaCodeInsightFixtureTestCase.java) (2019.2 and later) for tests that require the Java PSI or any related functionality.
   For plugins using pre-2019.2 versions use [`LightCodeInsightFixtureTestCase`](%gh-ic%/java/testFramework/src/com/intellij/testFramework/fixtures/LightCodeInsightFixtureTestCase.java).
+* [`LightJavaCodeInsightFixtureTestCase4`](%gh-ic%/java/testFramework/src/com/intellij/testFramework/fixtures/LightJavaCodeInsightFixtureTestCase4.java) (2021.1 and later) as the JUnit4 variant for `LightJavaCodeInsightFixtureTestCase`.
+* [`LightJavaCodeInsightFixtureTestCase5`](%gh-ic%/java/testFramework/src/com/intellij/testFramework/fixtures/LightJavaCodeInsightFixtureTestCase5.java) (2022.1 and later) as the JUnit5 variant for `LightJavaCodeInsightFixtureTestCase`.
 
 When writing a light test, you can specify the project's requirements that you need to have in your test, such as the module type, the configured [SDK](sdk.md), [facets](facet.md), [libraries](library.md), etc.
 You do so by extending the [`LightProjectDescriptor`](%gh-ic%/platform/testFramework/src/com/intellij/testFramework/LightProjectDescriptor.java) class and returning your project descriptor (usually stored in `static final` field) from `getProjectDescriptor()`.


### PR DESCRIPTION
### Changes
- Added `LightJavaCodeInsightFixtureTestCase4` and `LightJavaCodeInsightFixtureTestCase5` to the light and heavy tests article.
- Adde `LightJavaCodeInsightFixtureTestCase4` to the 2022 Notable API changes article.