### PR TITLE
Make docs files detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-detectable
+*.xml linguist-detectable


### PR DESCRIPTION
Currently, this project is detected as java. This change will change the GitHub UI to this

<img width="248" alt="image" src="https://github.com/JetBrains/intellij-sdk-docs/assets/16060205/e4a178a5-2e24-4221-9a06-d4b171ffbc40">
