### PR TITLE
Document GradleProjectResolverUtil.buildDependencies changes

### DIFF
--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -95,6 +95,9 @@ JsonPath library unbundled
 `com.intellij.profiler.eventtrace` package removed
 : Update code usages.
 
+`org.jetbrains.plugins.gradle.service.project.GradleProjectResolverUtil.buildDependencies(ProjectResolverContext, Map, Map, DataNode, Collection, DataNode)` method parameter type changed from `Map<String, String>` to `ArtifactMappingService`
+: Update usages of this method. Change parameter `artifactsMap` value to an `ArtifactMappingService` instance. It can be obtained from `ProjectResolverContext`, or created in-place using the `MapBasedArtifactMappingService`
+
 ### Collaboration Tools Module 2023.3
 
 `com.intellij.collaboration.ui.codereview.action.CodeReviewCheckoutRemoteBranchAction` class removed
@@ -176,15 +179,6 @@ Fragment builder functions from `ExternalSystemRunConfigurationUtil` file moved 
 
 `org.jetbrains.kotlin.idea.actions.JavaToKotlinAction.Companion` class renamed to `org.jetbrains.kotlin.idea.actions.JavaToKotlinAction.Handler`
 : In order to not load additional code eagerly on action instantiation.
-
-`org.jetbrains.kotlin.idea.facet.KotlinFacetConfiguration.getSettings()` method return type changed from `org.jetbrains.kotlin.config.KotlinFacetSettings` to `org.jetbrains.kotlin.config.IKotlinFacetSettings`
-: Use `IKotlinFacetSettings` interface instead of `KotlinFacetSettings` class. All fields and functionality are saved.
-
-`org.jetbrains.kotlin.config.KotlinFacetSettingsProvider.getInitializedSettings(Module)` method return type changed from `org.jetbrains.kotlin.config.KotlinFacetSettings` to `org.jetbrains.kotlin.config.IKotlinFacetSettings`
-: Use `IKotlinFacetSettings` interface instead of `KotlinFacetSettings` class. All fields and functionality are saved.
-
-`org.jetbrains.kotlin.config.KotlinFacetSettingsProvider.getSettings(Module)` method return type changed from `org.jetbrains.kotlin.config.KotlinFacetSettings` to `org.jetbrains.kotlin.config.IKotlinFacetSettings?`
-: Use `IKotlinFacetSettings` interface instead of `KotlinFacetSettings` class. All fields and functionality are saved.
 
 ### Markdown Plugin 2023.3
 


### PR DESCRIPTION
A method parameter type has changed. It should be updated in client code using either existing values from the context, or a wrapper around parameter of the previous type.