### PR TITLE
Document some incompatible Kotlin plugin changes for 2023.3

### DIFF
--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -190,10 +190,10 @@ Fragment builder functions from `ExternalSystemRunConfigurationUtil` file moved 
 : In order to not load additional code eagerly on action instantiation.
 
 `org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion.Companion` class removed
-: It was an internal API. Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
+: Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
 
 `org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion` class removed
-: It was an internal API. Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
+: Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
 
 
 ### Markdown Plugin 2023.3

--- a/reference_guide/api_changes_list_2023.md
+++ b/reference_guide/api_changes_list_2023.md
@@ -189,6 +189,13 @@ Fragment builder functions from `ExternalSystemRunConfigurationUtil` file moved 
 `org.jetbrains.kotlin.idea.actions.JavaToKotlinAction.Companion` class renamed to `org.jetbrains.kotlin.idea.actions.JavaToKotlinAction.Handler`
 : In order to not load additional code eagerly on action instantiation.
 
+`org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion.Companion` class removed
+: It was an internal API. Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
+
+`org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion` class removed
+: It was an internal API. Now, the Kotlin plugin version does not include a compiler version, so the class is unnecessary. Use `com.intellij.openapi.application.ApplicationInfo` to get the IntelliJ version.
+
+
 ### Markdown Plugin 2023.3
 
 `org.intellij.plugins.markdown.editor.images` package removed


### PR DESCRIPTION
`org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion` and `org.jetbrains.kotlin.idea.compiler.configuration.KotlinIdePluginVersion.Companion` internal API is removed.