### PR TITLE
Added a file Download section in jcef.md

### DIFF
--- a/topics/reference_guide/jcef.md
+++ b/topics/reference_guide/jcef.md
@@ -78,6 +78,35 @@ browser.openDevtools();
 
 See [`JBCefTestHelper`](%gh-ic%/platform/platform-tests/testSrc/com/intellij/ui/jcef/JBCefTestHelper.java) and tests in that package.
 
+## File Download
+
+Downloading files can be achieved by implementing the [`CefDownloadHandler`](https://github.com/JetBrains/jcef/blob/7560ce68418f8d8d1ac55a4fd318141053be8fea/java/org/cef/handler/CefDownloadHandler.java) interface and adding the download handler to the `JBCefClient`, as follows:
+
+```java
+JBCefBrowser browser = new JBCefBrowser();
+browser.getJBCefClient()
+       .addDownloadHandler(new SimpleDownloadHandler(), browser.getCefBrowser());
+```
+
+The `SimpleDownloadHandler` implements the `CefDownloadHandler` interface:
+
+```java
+public class SimpleDownloadHandler implements CefDownloadHandler {
+
+  @Override
+  public void onBeforeDownload(
+      CefBrowser browser,
+      CefDownloadItem downloadItem,
+      String suggestedName,
+      CefBeforeDownloadCallback callback) {
+    callback.Continue("", true);
+  }
+...
+}
+```
+
+Using the callback it opens the usual browser file download dialog.
+
 ## API
 
 ### JBCefApp

--- a/topics/reference_guide/jcef.md
+++ b/topics/reference_guide/jcef.md
@@ -80,7 +80,7 @@ See [`JBCefTestHelper`](%gh-ic%/platform/platform-tests/testSrc/com/intellij/ui/
 
 ## File Download
 
-Downloading files can be achieved by implementing the [`CefDownloadHandler`](https://github.com/JetBrains/jcef/blob/7560ce68418f8d8d1ac55a4fd318141053be8fea/java/org/cef/handler/CefDownloadHandler.java) and adding the download handler to the `JBCefClient`, as follows:
+Downloading files can be achieved by implementing the [`CefDownloadHandler`](https://github.com/JetBrains/jcef/blob/7560ce68418f8d8d1ac55a4fd318141053be8fea/java/org/cef/handler/CefDownloadHandler.java) and adding the download handler to the `JBCefClient`:
 
 ```java
 JBCefBrowser browser = new JBCefBrowser();

--- a/topics/reference_guide/jcef.md
+++ b/topics/reference_guide/jcef.md
@@ -80,7 +80,7 @@ See [`JBCefTestHelper`](%gh-ic%/platform/platform-tests/testSrc/com/intellij/ui/
 
 ## File Download
 
-Downloading files can be achieved by implementing the [`CefDownloadHandler`](https://github.com/JetBrains/jcef/blob/7560ce68418f8d8d1ac55a4fd318141053be8fea/java/org/cef/handler/CefDownloadHandler.java) interface and adding the download handler to the `JBCefClient`, as follows:
+Downloading files can be achieved by implementing the [`CefDownloadHandler`](https://github.com/JetBrains/jcef/blob/7560ce68418f8d8d1ac55a4fd318141053be8fea/java/org/cef/handler/CefDownloadHandler.java) and adding the download handler to the `JBCefClient`, as follows:
 
 ```java
 JBCefBrowser browser = new JBCefBrowser();
@@ -88,7 +88,7 @@ browser.getJBCefClient()
        .addDownloadHandler(new SimpleDownloadHandler(), browser.getCefBrowser());
 ```
 
-The `SimpleDownloadHandler` implements the `CefDownloadHandler` interface:
+The `SimpleDownloadHandler` implements the `CefDownloadHandler`:
 
 ```java
 public class SimpleDownloadHandler implements CefDownloadHandler {
@@ -105,7 +105,7 @@ public class SimpleDownloadHandler implements CefDownloadHandler {
 }
 ```
 
-Using the callback it opens the usual browser file download dialog.
+Using the callback it opens the browser file download dialog.
 
 ## API
 

--- a/topics/reference_guide/jcef.md
+++ b/topics/reference_guide/jcef.md
@@ -99,13 +99,12 @@ public class SimpleDownloadHandler implements CefDownloadHandler {
       CefDownloadItem downloadItem,
       String suggestedName,
       CefBeforeDownloadCallback callback) {
+    // Use the callback to open the browser file download dialog
     callback.Continue("", true);
   }
 ...
 }
 ```
-
-Using the callback it opens the browser file download dialog.
 
 ## API
 


### PR DESCRIPTION
I added a **file download section** in the JCEF part of the documentation.

It would be nice to have a short section pointing out how file downloads can be implemented since they do **not** work out of the box.

I implemented the file download using this method in my plugin ([visual debugger](https://github.com/timKraeuter/VisualDebugger)).

The link I added probably needs some adjustments to fit the other links in the documentation.

Let me know what you think.