### PR TITLE
Document `RestLanguage` moved to another package as part of V2 migration

### DIFF
--- a/reference_guide/api_changes_list_2024.md
+++ b/reference_guide/api_changes_list_2024.md
@@ -72,6 +72,8 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 
 ### IntelliJ Platform 2024.1
 
+`com.jetbrains.rest.RestLanguage` class moved to package `com.intellij.python.reStructuredText`
+
 `com.intellij.application.options.editor.CodeFoldingConfigurable.applyCodeFoldingSettingsChanges()` method removed
 : Use top-level method `CodeFoldingConfigurableKt.applyCodeFoldingSettingsChanges` instead.
 


### PR DESCRIPTION
As part of migration to v2 modules we moved this class to another package.

See `4da3e7da0dcd86d454972b2ef68d2581c7fe5cdb`