### PR TITLE
Document `com.jetbrains.commandInterface` moved to another package as part of V2 migration

### DIFF
--- a/reference_guide/api_changes_list_2024.md
+++ b/reference_guide/api_changes_list_2024.md
@@ -72,6 +72,14 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 
 ### IntelliJ Platform 2024.1
 
+`com.jetbrains.commandInterface.commandLine.psi.CommandLineFile` class moved to package `com.intellij.commandInterface.commandLine.psi`
+
+`com.jetbrains.commandInterface.commandLine.CommandLineLanguage` class moved to package `com.intellij.commandInterface.commandLine`
+
+`com.jetbrains.commandInterface.commandLine.psi.CommandLineArgument` class moved to package `com.intellij.commandInterface.commandLine.psi`
+
+`com.jetbrains.commandInterface.commandLine.psi.CommandLineOption` class moved to package `com.intellij.commandInterface.commandLine.psi`
+
 `com.intellij.application.options.editor.CodeFoldingConfigurable.applyCodeFoldingSettingsChanges()` method removed
 : Use top-level method `CodeFoldingConfigurableKt.applyCodeFoldingSettingsChanges` instead.
 


### PR DESCRIPTION
As part of migration to v2 modules we moved this class to another package.

See `18dcc57922878c8ad1fe0bb6be85097d4d81cc34`