### PR TITLE
[IJSDK-1942] Update storage guidance in documentation

### DIFF
--- a/topics/basics/persisting_state_of_components.md
+++ b/topics/basics/persisting_state_of_components.md
@@ -176,12 +176,12 @@ The simplest ways of specifying the `@Storage` annotation are as follows:
 
 The state is persisted in a separate file by specifying a different setting for the `value` parameter, which was the `file` parameter before 2016.x.
 
-See [`StoragePathMacros`](%gh-ic%/platform/projectModel-api/src/com/intellij/openapi/components/StoragePathMacros.java) for commonly used values.
-
 > For application-level storage, it is strongly recommended to use a custom file.
 > Using of <path>other.xml</path> is deprecated.
 >
 {style="note"}
+
+When planning your storage location, consider its intended purpose. A project-level custom file should be preferred for storing plugin settings. For storing cached values, use `@Storage(StoragePathMacros.CACHE_FILE)`. Refer to [`StoragePathMacros`](%gh-ic%/platform/projectModel-api/src/com/intellij/openapi/components/StoragePathMacros.java) for commonly used macros.
 
 The `roamingType` parameter of the `@Storage` annotation specifies the roaming type when the [settings are shared](#sharing-settings-between-ide-installations):
 


### PR DESCRIPTION
The instructions for planning storage location have been updated to provide more context. The updated version emphasizes the use of a project-level custom file for plugin settings and recommends `@Storage(StoragePathMacros.CACHE_FILE)` for cached values. Reference to `StoragePathMacros` for commonly used macros is included in the new text.