### PR TITLE
Fixed comment string.

### DIFF
--- a/topics/tutorials/custom_language_support/annotator.md
+++ b/topics/tutorials/custom_language_support/annotator.md
@@ -68,7 +68,7 @@ Annotate the `simple:key` literal expression, and differentiate between a well-f
 ```
 {src="simple_language_plugin/src/main/java/org/intellij/sdk/language/SimpleAnnotator.java" include-symbol="SimpleAnnotator"}
 
-> If the above code is copied at this stage of the tutorial, then remove the line below the comment "** Tutorial step 18.3 …" The quick fix class in that line is not defined until later in the tutorial.
+> If the above code is copied at this stage of the tutorial, then remove the line below the comment "** Tutorial step 19. …" The quick fix class in that line is not defined until later in the tutorial.
 >
 
 ## Register the Annotator


### PR DESCRIPTION
In the source code 
`// ** Tutorial step 19. - Add a quick fix for the str`
but in documentation Tutorial step 18.3. Fixed it.