### PR TITLE
`com.jetbrains.python.debugger.remote` removed

### DIFF
--- a/reference_guide/api_changes_list_2024.md
+++ b/reference_guide/api_changes_list_2024.md
@@ -74,6 +74,9 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 
 
 ### IntelliJ Platform 2024.1
+`com.jetbrains.python.debugger.remote` package removed
+: Private package is no longer available as an API.
+
 `com.intellij.refactoring.RefactoringHelper.prepareOperation(UsageInfo [] usages, List<PsiElement> elements)` abstract method added
 : Use instead of `com.intellij.refactoring.RefactoringHelper.prepareOperation(UsageInfo [] usages)` and `com.intellij.refactoring.RefactoringHelper.prepareOperation(UsageInfo [] usages, PsiElement primaryElement)`.
 


### PR DESCRIPTION
Internal, ultimate-only package which isn't even available in community version should never be used outside of JB