### PR TITLE
Document gutter icon size for the new UI

### DIFF
--- a/topics/reference_guide/icons.md
+++ b/topics/reference_guide/icons.md
@@ -130,6 +130,7 @@ Required icon sizes depend on the usage as listed in the following table:
 | Node, Action, Filetype | 16x16              |
 | Tool window            | 13x13              |
 | Editor gutter          | 12x12              |
+| Editor gutter (New UI) | 14x14              |
 
 ### SVG Format
 


### PR DESCRIPTION
In the New UI, gutter icons are 14x14 en-masse.

Document this recommendation to have a single-source of truth.

See the [Slack discussion](https://jetbrains.slack.com/archives/C0AEUGGMD/p1712833039835489?thread_ts=1709238291.725849&cid=C0AEUGGMD).