### PR TITLE
Fixes code examples of improperly nested labels

### DIFF
--- a/topics/reference_guide/settings_groups.md
+++ b/topics/reference_guide/settings_groups.md
@@ -75,7 +75,7 @@ The example below demonstrates a nested `configurable` declaration:
         id="com.intellij.sdk.tasks"
         displayName="Tasks"
         nonDefaultProject="true"
-        instance="com.intellij.sdk.TaskConfigurable"/>
+        instance="com.intellij.sdk.TaskConfigurable">
     <configurable
         id="com.intellij.sdk.tasks.servers"
         displayName="Servers"


### PR DESCRIPTION
Nested xml tags, but prematurely closed the tags.
- fix before:

```
<projectConfigurable/><projectConfigurable/></projectConfigurable>
```

- fix after:

```
<projectConfigurable><projectConfigurable/></projectConfigurable>
```