### PR TITLE
PropertiesQuickFixFactory.createRemovePropertyLocalFix()

### DIFF
--- a/reference_guide/api_changes_list_2024.md
+++ b/reference_guide/api_changes_list_2024.md
@@ -213,6 +213,11 @@ Visibility of class `com.intellij.util.CachedValuesFactory` changed from public 
 `com.intellij.lang.properties.RemovePropertyLocalFix` class removed
 : Use `com.intellij.codeInsight.daemon.impl.quickfix.DeleteElementFix` instead.
 
+### Properties Plugin 2024.1
+
+`com.intellij.lang.properties.PropertiesQuickFixFactory.createRemovePropertyLocalFix()` method parameter `Property property` added.
+: Supply the property that the fix should be applied for.
+
 ### Django Plugin 2024.1
 
 Package `com.jetbrains.jinja2` renamed to `com.intellij.jinja`


### PR DESCRIPTION
The instruction does not show the sample when a new parameter is added to an existing method. Hopefully, it's ok to describe such an incompatibility. Describing in two sections 'method removed' and 'method added' would be too pedantic...