### PR TITLE
Add HTTP Client changes to api_changes_list_2024.md

### DIFF
--- a/reference_guide/api_changes_list_2024.md
+++ b/reference_guide/api_changes_list_2024.md
@@ -120,6 +120,11 @@ NOTE: Entries not starting with code quotes (`name`) can be added to document no
 `com.intellij.database.datagrid.DataGrid.adaptForNewQuery()` abstract method added
 : Only recompilation is needed for classes that implement `DataGrid` and delegate calls to an actual `DataGrid` implementation.
 
+### HTTP Client Plugin 2024.2
+`com.intellij.httpClient.http.request.HttpRequestPsiConverter.toRequestConfig(HttpRequest)` method visibility changed from `public` to `private`
+: This method is an implementation detail.
+
+
 ## 2024.1
 
 ### IntelliJ Platform 2024.1


### PR DESCRIPTION
There is a change in internal method, that was accidentally made public. It cannot be reverted because it breaks compatibility anyway, because it also throws a checked exception now. And this exception is necessary for new functionality.