### PR TITLE
Update usage of pluginName in tools_intellij_platform_gradle_plugin_recipes.md

### DIFF
--- a/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_recipes.md
+++ b/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_recipes.md
@@ -108,7 +108,7 @@ Additional files can be bundled by adding them to the plugin directory when prep
 tasks {
   prepareSandbox {
     from(layout.projectDirectory.dir("extraFiles")) {
-      into(pluginName.map { "$it/extra" })
+      into(intellijPlatform.pluginConfiguration.name.map { "$it/extra" })
     }
   }
 }
@@ -120,7 +120,7 @@ tasks {
 ```groovy
 tasks.named('prepareSandbox', PrepareSandboxTask) {
   from layout.projectDirectory.dir('extraFiles')
-  into it.pluginName.map { "$it/extra" }
+  into intellijPlatform.pluginConfiguration.name.map { "$it/extra" }
 }
 ```
 


### PR DESCRIPTION
Maybe I understood I did the update to 2.0 incorrectly, but `pluginName` doesn't work for me, but `intellijPlatform.pluginConfiguration.name` (described [here](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html#intellijpluginname)) works fine. 
I didn't test groovy version, since I only use kts, but presume it should the same

As a sidenote for the plugin template, is it on purpose that only the [version is assigned explicitly](https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/build.gradle.kts#L56), but the name isn't. I had to assign it as well for the property to work