### PR TITLE
Better wording for restricted attributes of light services

### DIFF
--- a/topics/basics/plugin_structure/plugin_services.md
+++ b/topics/basics/plugin_structure/plugin_services.md
@@ -58,7 +58,7 @@ The service instance will be created in scope according to the caller (see [](#r
 
 ### Light Service Restrictions
 
-* None of these attributes is required: `os`, `client`, `overrides`, `id`, `preload`.
+* None of these attributes is allowed: `os`, `client`, `overrides`, `id`, `preload`.
 * Service class must be `final`.
 * [Constructor injection](#ctor) of dependency services is not supported.
 * If application-level service is a [PersistentStateComponent](persisting_state_of_components.md), roaming must be disabled (`roamingType = RoamingType.DISABLED`).


### PR DESCRIPTION
"None of these attributes is required" implies that those attributes can be specified for light services and also that they are required for non-light services