### PR TITLE
Document removal of IrDeserializer.IrLinkerExtension and related classes in API changes

### DIFF
--- a/reference_guide/api_changes_list_2025.md
+++ b/reference_guide/api_changes_list_2025.md
@@ -87,3 +87,9 @@ Coroutines running under `Dispatchers.Main` do not hold the write-intent lock
 
 `org.jetbrains.kotlin.KtFakeSourceElement` class renamed to `org.jetbrains.kotlin.KtFakePsiSourceElement`
 : Update code usages.
+
+`org.jetbrains.kotlin.ir.linkage.IrDeserializer.IrLinkerExtension` class removed
+: This class from Kotlin compiler was removed and should not be used anymore.
+
+`org.jetbrains.kotlin.ir.builders.TranslationPluginContext` class removed
+: This class from Kotlin compiler was removed and should not be used anymore.

--- a/reference_guide/api_changes_list_2025.md
+++ b/reference_guide/api_changes_list_2025.md
@@ -92,4 +92,4 @@ Coroutines running under `Dispatchers.Main` do not hold the write-intent lock
 : This class was removed from the Kotlin compiler and is no longer available.
 
 `org.jetbrains.kotlin.ir.builders.TranslationPluginContext` class removed
-: This class from Kotlin compiler was removed and should not be used anymore.
+: This class was removed from the Kotlin compiler and is no longer available. 

--- a/reference_guide/api_changes_list_2025.md
+++ b/reference_guide/api_changes_list_2025.md
@@ -89,7 +89,7 @@ Coroutines running under `Dispatchers.Main` do not hold the write-intent lock
 : Update code usages.
 
 `org.jetbrains.kotlin.ir.linkage.IrDeserializer.IrLinkerExtension` class removed
-: This class from Kotlin compiler was removed and should not be used anymore.
+: This class was removed from the Kotlin compiler and is no longer available.
 
 `org.jetbrains.kotlin.ir.builders.TranslationPluginContext` class removed
 : This class from Kotlin compiler was removed and should not be used anymore.


### PR DESCRIPTION
See the commit which removed this:
https://github.com/JetBrains/kotlin/commit/c2122dbae14eed172ac1a4115a14ba4f82e0b7f9

In general, this incompatibility change should not be triggered anywhere, unless someone tries to call the missing `IrDeserializer.IrLinkerExtension.resolveSymbol` by hand. We do not see any such External Usages