### PR TITLE
Document changes in the Analysis API in 2025.1

### DIFF
--- a/reference_guide/api_changes_list_2025.md
+++ b/reference_guide/api_changes_list_2025.md
@@ -99,6 +99,12 @@ Coroutines running under `Dispatchers.Main` do not hold the write-intent lock
 `org.jetbrains.kotlin.ir.builders.TranslationPluginContext` class removed
 : This class was removed from the Kotlin compiler and is no longer available. 
 
+`org.jetbrains.kotlin.analysis.api.symbols.KaReceiverParameterSymbol.type` property is removed
+: Property deprecated in 2024.2 is removed. Use `KaReceiverParameterSymbol.returnType` instead.
+
+`org.jetbrains.kotlin.analysis.api.contracts.description.KaContractParameterValue.parameterSymbol` property is removed
+: Experimental API has changed. Use `KaContractParameterValue.symbol` instead.
+
 ### Remote Development 2025.1
 
 `com.jetbrains.rd.ide.model.AddToGroupRuleModel` class removed


### PR DESCRIPTION
In 2025.1, there were changes in the Analysis API related to previously deprecated and experimental endpoints.