### PR TITLE
Document internal changes in Kotlin compiler

### DIFF
--- a/reference_guide/api_changes_list_2025.md
+++ b/reference_guide/api_changes_list_2025.md
@@ -119,6 +119,9 @@ Class `com.intellij.psi.xml.XmlElementType` no longer extends `com.intellij.psi.
 `org.jetbrains.kotlin.ir.builders.TranslationPluginContext` class removed
 : This class was removed from the Kotlin compiler and is no longer available.
 
+`org.jetbrains.kotlin.analysis.decompiler.stub.file.ClsClassFinder.isKotlinInternalCompiledFile$default(ClsClassFinder, VirtualFile, byte[], int, Object)` method removed
+: Recompile code usages.
+
 ### Remote Development 2025.1
 
 `com.jetbrains.rd.ide.model.AddToGroupRuleModel` class removed


### PR DESCRIPTION
A new parameter was added to the function with default arguments. This is an incompatible change for Kotlin code (Java usages are not affected)