### PR TITLE
Update ide.tooltip.initialReshowDelay value

### DIFF
--- a/topics/ui/controls/tooltip.md
+++ b/topics/ui/controls/tooltip.md
@@ -285,7 +285,7 @@ If the mouse cursor stays in the tooltip trigger area, tooltips are also hidden 
         Action
     </td>
     <td>
-        <p>300 milliseconds</p>
+        <p>500 milliseconds</p>
         <p><format color="#999999">ide.tooltip.initialReshowDelay registry key</format></p>
     </td>
     <td>


### PR DESCRIPTION
Looking at the current source code, the value is 500.

For reference https://github.com/JetBrains/intellij-community/blob/master/platform/util/resources/misc/registry.properties#L328