### PR TITLE
Fix `noSearchableOptionsWarning` example

### DIFF
--- a/topics/appendix/tools/gradle_intellij_plugin/tools_gradle_intellij_plugin_build_features.md
+++ b/topics/appendix/tools/gradle_intellij_plugin/tools_gradle_intellij_plugin_build_features.md
@@ -34,7 +34,7 @@ Default value
 Example
 :
 ```
-org.jetbrains.intellij.buildFeature.buildSearchableOptions=false
+org.jetbrains.intellij.buildFeature.noSearchableOptionsWarning=false
 ```
 
 

--- a/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_gradle_properties.md
+++ b/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_gradle_properties.md
@@ -85,7 +85,7 @@ Default value
 Example
 :
 ```
-org.jetbrains.intellij.platform.buildSearchableOptions=false
+org.jetbrains.intellij.platform.noSearchableOptionsWarning=false
 ```
 
 


### PR DESCRIPTION
I noticed the example references `buildSearchableOptions` instead of `noSearchableOptionsWarning`.