### PR TITLE
Add note about no longer needing to specify `jetbrainsRuntime()` in the `repositories` block if `defaultRepositories()` is specified

### DIFF
--- a/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_jetbrains_runtime.md
+++ b/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_jetbrains_runtime.md
@@ -78,6 +78,7 @@ dependencies {
 </tab>
 </tabs>
 
+**Note:** As of version `2.2.0` of the IntelliJ Platform Gradle Plugin, explicitly specifying `jetbrainsRuntime()` in the `repositories` block is no longer necessary if you also have `defaultRepositories()` specified.
 
 ## Declared Explicitly
 
@@ -138,6 +139,7 @@ dependencies {
 </tab>
 </tabs>
 
+**Note:** As of version `2.2.0` of the IntelliJ Platform Gradle Plugin, explicitly specifying `jetbrainsRuntime()` in the `repositories` block is no longer necessary if you also have `defaultRepositories()` specified.
 
 Provided `version`, `variant`, and `architecture` parameters along with the `explicitVersion` are used to resolve the JetBrains Runtime archives published on [GitHub Releases](https://github.com/JetBrains/JetBrainsRuntime/releases/) page.
 


### PR DESCRIPTION
`jetbrainsRuntime()` is included in `defaultRepositories()` as of 2.2.0 and beyond. See https://github.com/JetBrains/intellij-platform-gradle-plugin/commit/15e2e761e93c710dad5191c4adde1c8e31e131fd#diff-82e7d88bf5dd0c647f41082a1f71d9e802bb9b67f78d9f7a6497614f1abc9078R230