### PR TITLE
Adding documentation for `intellijPlatformIdesCache` property

### DIFF
--- a/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_gradle_properties.md
+++ b/topics/appendix/tools/intellij_platform_gradle_plugin/tools_intellij_platform_gradle_plugin_gradle_properties.md
@@ -57,6 +57,26 @@ org.jetbrains.intellij.platform.intellijPlatformCache=/path/to/intellijPlatformC
 ```
 
 
+## `intellijPlatformIdesCache`
+{#intellijPlatformIdesCache}
+
+Specifies the location of the IntelliJ Platform IDEs cache directory for storing downloaded IDE distributions
+and related artifacts. This cache is used to avoid re-downloading the same IDE versions across different
+project builds and can be shared between multiple projects.
+
+**Note:** this directory can be shared across projects and should be excluded from versioning.
+
+{type="narrow"}
+Default value
+: <path>[intellijPlatformCache]/ides/</path>
+
+Example
+:
+```
+org.jetbrains.intellij.platform.intellijPlatformIdesCache=/path/to/intellijPlatformCache/ides
+```
+
+
 ## `localPlatformArtifacts`
 {#localPlatformArtifacts}
 


### PR DESCRIPTION
Adding user-facing docs based on the JavaDoc found here: https://github.com/JetBrains/intellij-platform-gradle-plugin/commit/60a22714630f0b0b9809c30f4ed5b0efa57c77f5#diff-0b7a967bdf021b4ac2ea9ed35db82ec354abb882687c57f78fdb7902eb7b5377R65-R75

CC @hsz (as original author of above linked commit)