### PR TITLE
Update light_and_heavy_tests.md - remove reference to deprecated `LightPlatformTestCase`

### DIFF
--- a/topics/basics/testing_plugins/light_and_heavy_tests.md
+++ b/topics/basics/testing_plugins/light_and_heavy_tests.md
@@ -29,8 +29,7 @@ The standard way of writing a light test is to extend one of the following class
 <tabs>
 <tab title="Default">
 
-Use [`LightPlatformTestCase`](%gh-ic%/platform/testFramework/src/com/intellij/testFramework/LightPlatformTestCase.java)
-or [`BasePlatformTestCase`](%gh-ic%/platform/testFramework/src/com/intellij/testFramework/fixtures/BasePlatformTestCase.java)
+Use [`BasePlatformTestCase`](%gh-ic%/platform/testFramework/src/com/intellij/testFramework/fixtures/BasePlatformTestCase.java)
 for tests that don't have any dependency on Java functionality.
 
 **Examples:**


### PR DESCRIPTION
Ideally, the docs wouldn't guide a user to use a class that's deprecated - I recommend removing this reference so that developers are guided to use something 'current' and not deprecated.