### PR TITLE
Add "asynchronous vfs updates" to 2026.2 changelist

### DIFF
--- a/topics/appendix/api_notable/api_notable_list_2026.md
+++ b/topics/appendix/api_notable/api_notable_list_2026.md
@@ -12,11 +12,8 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 
 Asynchronous `VirtualFile` content saving
 :
-[`VirtualFile`](%gh-ic%/platform/core-api/src/com/intellij/openapi/vfs/VirtualFile.java) content update via `getOutputStream()` or `setBinaryContent()` could now be postponed – the actual file on disk could be modified with some delay.
-With content writing IO moved outside enclosing write action, the enclosing WA finishes quicker, thus reducing UI freezes.
-The IO postponing is invisible for accesses via VFS – VFS maintains an illusion the update is fully finished, while it is still in flight – but could be visible if one accesses the same file bypassing VFS – either via `java.io`/`java.nio` API directly, or from an external process.
-To be sure the possible asynchronous IO is really finished – use [`ManagingFS.getInstance().flushPendingUpdates()`](%gh-ic%/platform/analysis-api/src/com/intellij/openapi/vfs/newvfs/ManagingFS.java)
-
+[`VirtualFile`](%gh-ic%/platform/core-api/src/com/intellij/openapi/vfs/VirtualFile.java) content updates via `getOutputStream()` or `setBinaryContent()` can now be postponed – the actual file on disk may be modified with some delay.
+See [](virtual_file.md#when-are-virtualfile-changes-persisted-on-disk-and-loaded-from-disk-to-vfs) for more details.
 
 ## 2026.1
 

--- a/topics/appendix/api_notable/api_notable_list_2026.md
+++ b/topics/appendix/api_notable/api_notable_list_2026.md
@@ -8,6 +8,16 @@ _Early Access Program_ (EAP) releases of upcoming versions are available [here](
 
 <include from="snippets.topic" element-id="gradlePluginVersion"/>
 
+### IntelliJ Platform 2026.2
+
+Asynchronous `VirtualFile` content saving
+:
+[`VirtualFile`](%gh-ic%/platform/core-api/src/com/intellij/openapi/vfs/VirtualFile.java) content update via `getOutputStream()` or `setBinaryContent()` could now be postponed – the actual file on disk could be modified with some delay.
+With content writing IO moved outside enclosing write action, the enclosing WA finishes quicker, thus reducing UI freezes.
+The IO postponing is invisible for accesses via VFS – VFS maintains an illusion the update is fully finished, while it is still in flight – but could be visible if one accesses the same file bypassing VFS – either via `java.io`/`java.nio` API directly, or from an external process.
+To be sure the possible asynchronous IO is really finished – use [`ManagingFS.getInstance().flushPendingUpdates()`](%gh-ic%/platform/analysis-api/src/com/intellij/openapi/vfs/newvfs/ManagingFS.java)
+
+
 ## 2026.1
 
 ### IntelliJ Platform 2026.1

--- a/topics/basics/architectural_overview/virtual_file.md
+++ b/topics/basics/architectural_overview/virtual_file.md
@@ -51,6 +51,15 @@ As a general rule, files are created either through the [PSI API](psi.md) or thr
 
 If one needs to create a file through VFS, use `VirtualFile.createChildData()` to create a `VirtualFile` instance and `VirtualFile.setBinaryContent()` to write some data to the file.
 
+## When `VirtualFile` changes come to disk, and vise versa?
+The changes to a `VirtualFile` (e.g., `setBinaryContent()`) may reach the underlying files with some delay – i.e., the actual IO could be postponed, and executed asynchronously.
+To ensure the changes have been applied forcibly – e.g., to read the new file content from an external process – use `ManagingFS.getInstance().flushPendingUpdates()` (outside write action).
+
+The changes in the underlying files also reach VFS with some (normally, short) delay.
+`VirtualFile.refresh()` could be used to ensure the changes are noticed.
+It could introduce significant delay, so use it with caution.
+More about refreshing in [Virtual File System (VFS)](virtual_file_system.md).
+
 ## How do I get notified when VFS changes?
 
 > See [](virtual_file_system.md#virtual-file-system-events) for important details.

--- a/topics/basics/architectural_overview/virtual_file.md
+++ b/topics/basics/architectural_overview/virtual_file.md
@@ -51,14 +51,19 @@ As a general rule, files are created either through the [PSI API](psi.md) or thr
 
 If one needs to create a file through VFS, use `VirtualFile.createChildData()` to create a `VirtualFile` instance and `VirtualFile.setBinaryContent()` to write some data to the file.
 
-## When `VirtualFile` changes come to disk, and vise versa?
-The changes to a `VirtualFile` (e.g., `setBinaryContent()`) may reach the underlying files with some delay – i.e., the actual IO could be postponed, and executed asynchronously.
-To ensure the changes have been applied forcibly – e.g., to read the new file content from an external process – use `ManagingFS.getInstance().flushPendingUpdates()` (outside write action).
+## When are `VirtualFile` changes persisted on disk and loaded from disk to VFS?
 
-The changes in the underlying files also reach VFS with some (normally, short) delay.
+Since version 2026.2, changes to a `VirtualFile` (`getOutputStream()` or `setBinaryContent()`) may reach the underlying files with some delay – the actual IO is postponed and executed asynchronously.
+
+With content writing I/O moved outside the enclosing write action, the enclosing write action finishes quicker, thus reducing UI freezes.
+The I/O postponing is invisible for access via VFS – VFS maintains the illusion that the update is fully finished while it is still ongoing.
+However, it may be visible if the same file is accessed bypassing VFS, either via `java.io`/`java.nio` API directly or from an external process.
+To ensure changes have been applied forcibly – for example, to read the new file content from an external process – use [`ManagingFS.getInstance().flushPendingUpdates()`](%gh-ic%/platform/analysis-api/src/com/intellij/openapi/vfs/newvfs/ManagingFS.java) (outside write action).
+
+Changes in the underlying files also reach VFS with some (normally, short) delay.
 `VirtualFile.refresh()` could be used to ensure the changes are noticed.
 It could introduce significant delay, so use it with caution.
-More about refreshing in [Virtual File System (VFS)](virtual_file_system.md).
+More about refreshing in [Virtual File System (VFS)](virtual_file_system.md#synchronous-and-asynchronous-refreshes).
 
 ## How do I get notified when VFS changes?
 


### PR DESCRIPTION
New behavior: asynchronous updates execution by vfs -- is added in 2026.2, plugin developers needs to know about it