### PR TITLE
Fix missing plugin metadata in OAuth 2.0 Sample

### DIFF
--- a/code_samples/oauth2/gradle.properties
+++ b/code_samples/oauth2/gradle.properties
@@ -1,4 +1,7 @@
-# Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+# Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+group = org.intellij.sdk
+version = 1.0.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/code_samples/oauth2/src/main/resources/META-INF/plugin.xml
+++ b/code_samples/oauth2/src/main/resources/META-INF/plugin.xml
@@ -1,10 +1,19 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
   <id>org.intellij.sdk.oauth2</id>
-  <name>OAuth2 Example</name>
-  <vendor>hsz</vendor>
+  <name>SDK: OAuth2 2.0 Sample</name>
+  <vendor url="https://plugins.jetbrains.com">IntelliJ Platform SDK</vendor>
 
   <depends>com.intellij.modules.platform</depends>
+
+  <description>
+    <![CDATA[
+      Demonstrates how to add an OAuth2 login flow to a plugin.
+      <br>
+      Uses GitHub as the provider and implements the authorization-code flow with PKCE.
+    ]]>
+
+  </description>
 
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable instance="org.intellij.sdk.oauth2.AuthConfigurable"


### PR DESCRIPTION
Plugin version and description is mandatory, so add them. Align name and group with other plugins.

This fixes failing tests when Plugin Verifier fails on descriptor validation.