### PR TITLE
Add extended error reporting page to documentation

### DIFF
--- a/ijs.tree
+++ b/ijs.tree
@@ -91,7 +91,9 @@
       <toc-element topic="messaging_infrastructure.md"/>
       <!--<toc-element toc-title="Queries and Query Executors"/>--><!--TODO-->
     </toc-element>
-    <toc-element topic="ide_infrastructure.md"/>
+    <toc-element topic="ide_infrastructure.md">
+      <toc-element topic="error_reporting.md"/>
+    </toc-element>
     <toc-element topic="user_interface_components.md">
       <toc-element topic="tool_windows.md"/>
       <toc-element topic="dialog_wrapper.md"/>

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -183,7 +183,7 @@ Register it in <path>plugin.xml</path>:
 
 ```xml
 <extensions defaultExtensionNs="com.intellij">
-  <errorReportSink implementation="my.plugin.MyErrorReportSink"/>
+  <errorReportSink implementation="com.example.MyErrorReportSink"/>
 </extensions>
 ```
 

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -96,7 +96,7 @@ The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platfor
 - `consumer` - callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java).
 This is the main integration point for building a custom payload for an issue tracker or backend service.
 
-If `submit()` returns `true`, the submitter is declaring that submission has started and the callback will be completed later.
+If `submit()` returns `true`, the submitter is declaring that the submission has started and the callback will be completed later.
 The callback must eventually receive a `SubmittedReportInfo` stating if a `NEW_ISSUE` has been filed, the report was a
 `DUPLICATE`, or if the submission has `FAILED` altogether.
 

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -205,8 +205,9 @@ class MyErrorReportSink : ErrorReportSink {
 }
 ```
 
-`ErrorReportSink` currently delivers two report types. `UnhandledExceptionReport` contains the exception class and stack trace.
-`UnhandledFreezeReport` contains a message, the freeze duration, attachments, and thread dumps.
+`ErrorReportSink` currently delivers two report types:
+- `UnhandledExceptionReport` contains the exception class and stack trace
+- `UnhandledFreezeReport` contains a message, the freeze duration, attachments, and thread dumps
 
 `ErrorReportSink` is intended for plugin observability, not guaranteed report delivery.
 Bundled IDE plugins are not notified about their errors, at most 10,000 exception reports per plugin per IDE session are forwarded,

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -89,7 +89,11 @@ Where:
 - `getPrivacyNoticeText()` must explain to users what data is sent and how it is used
 - `submit()` performs the actual submission
 
-The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) data selected for the report, the free-form text entered by the user in the comment box as `additionalInfo`, a `parentComponent` for any necessary interaction, and a `consumer` callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java). An `IdeaLoggingEvent` gives access to the core report data, such as the throwable, message text, and attachments included in the report.
+The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) data selected for the report:
+- events - `IdeaLoggingEvent` instances give access to the core report data, such as the throwable, message text, and attachments included in the report
+- `additionalInfo` - the free-form text entered by the user in the comment box as 
+- `parentComponent` - for any necessary interaction
+- `consumer` - callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java).
 This is the main integration point for building a custom payload for an issue tracker or backend service.
 
 If `submit()` returns `true`, the submitter is declaring that submission has started and the callback will be completed later.

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -102,7 +102,7 @@ The callback must eventually receive a `SubmittedReportInfo` with the proper `Su
 - `DUPLICATE` - if the issue is actually a duplicate of the existing one
 - `FAILED` - if the submission failed
 
-If submission cannot even start, you must return `false` from `submit()`.
+If submission cannot even start, `submit()` must return `false`.
 
 > Do not leave the callback unfinished after returning `true`.
 > The IDE uses that callback to update the reporting UI and final submission state.

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -212,8 +212,10 @@ Plugins should still keep sink processing short, deduplicate repeated failures, 
 Use `ErrorReportSubmitter` when the user should explicitly submit the report, when the plugin needs the user comment,
 when a custom privacy notice or account-aware reporting is required, or when the backend expects a richer user-facing reporting flow.
 
-Use `ErrorReportSink` when the plugin should observe failures even if the user does nothing, when the goal is telemetry,
-counting, alerting, or best-effort backend forwarding, or when automatic freeze visibility is important.
+Use `ErrorReportSink` when:
+- the plugin should observe failures even if the user does nothing
+- the goal is telemetry, counting, alerting, or best-effort backend forwarding
+- automatic freeze visibility is important
 
 Use both APIs when the plugin needs background observability during normal usage and also a richer user-driven reporting path for manual submission.
 

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -84,8 +84,10 @@ class MyErrorReportSubmitter : ErrorReportSubmitter() {
 }
 ```
 
-Here, `getReportActionText()` defines the text shown on the report button in the reporting UI,
-`getPrivacyNoticeText()` must explain to users what data is sent and how it is used, and `submit()` performs the actual submission.
+Where:
+- `getReportActionText()` defines the text shown on the report button in the reporting UI
+- `getPrivacyNoticeText()` must explain to users what data is sent and how it is used
+- `submit()` performs the actual submission
 
 The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) data selected for the report, the free-form text entered by the user in the comment box as `additionalInfo`, a `parentComponent` for any necessary interaction, and a `consumer` callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java). An `IdeaLoggingEvent` gives access to the core report data, such as the throwable, message text, and attachments included in the report.
 This is the main integration point for building a custom payload for an issue tracker or backend service.

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -97,8 +97,10 @@ The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platfor
 This is the main integration point for building a custom payload for an issue tracker or backend service.
 
 If `submit()` returns `true`, the submitter is declaring that the submission has started and the callback will be completed later.
-The callback must eventually receive a `SubmittedReportInfo` stating if a `NEW_ISSUE` has been filed, the report was a
-`DUPLICATE`, or if the submission has `FAILED` altogether.
+The callback must eventually receive a `SubmittedReportInfo` with the proper `SubmissionStatus`:
+- `NEW_ISSUE` - if the issue has been successfully filed
+- `DUPLICATE` - if the issue is actually a duplicate of the existing one
+- `FAILED` - if the submission failed
 
 If submission cannot even start, you must return `false` from `submit()`.
 

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -23,18 +23,21 @@ and a callback used to complete the submission flow.
 
 `ErrorReportSink` is the automatic background reporting API.
 It is triggered when the platform automatically forwards a plugin-attributed exception or freeze, so no user action is required.
-It is typically used for telemetry, counters, deduplication, and best-effort backend forwarding.
 The sink receives either [`UnhandledExceptionReport`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt)
 or [`UnhandledFreezeReport`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt),
 which makes it suitable for observability scenarios even when the user never clicks a reporting action.
 
-<video src="https://www.youtube.com/watch?v=F4ZQe3AU3v4" title="How We Built Comma, the Raku IDE, on the IntelliJ Platform"/>
+<video src="https://www.youtube.com/watch?v=F4ZQe3AU3v4"/>
 
-## The Easy Way: JetBrains Marketplace Exception Analyzer
+## Manual Reporting
+
+### JetBrains Marketplace Exception Analyzer
 
 If the plugin is published on JetBrains Marketplace and the built-in reporting flow is sufficient, this is the simplest supported setup.
 
-Register the Marketplace submitter in <path>plugin.xml</path>:
+Register [`JetBrainsMarketplaceErrorReportSubmitter`](%gh-ic%/platform/platform-impl/src/com/intellij/diagnostic/JetBrainsMarketplaceErrorReportSubmitter.kt)
+as an implementation of the <include from="snippets.topic" element-id="ep"><var name="ep" value="com.intellij.errorHandler"/></include>
+in <path>plugin.xml</path>:
 
 ```xml
 <extensions defaultExtensionNs="com.intellij">
@@ -48,7 +51,7 @@ The IDE uses the built-in submitter to send reports to the backend provided by J
 See [JetBrains Exception Analyzer](https://plugins.jetbrains.com/docs/marketplace/exception-analyzer.html)
 for setup details and current product-specific behavior.
 
-## Custom Implementation of `ErrorReportSubmitter`
+### Custom Implementation of `ErrorReportSubmitter`
 
 Use a custom submitter when the plugin needs control over the backend, payload, privacy notice, or the post-submission workflow.
 
@@ -70,7 +73,8 @@ class MyErrorReportSubmitter : ErrorReportSubmitter() {
   override fun getReportActionText(): String = "Report to Vendor"
 
   override fun getPrivacyNoticeText(): String =
-    "The report may contain stack traces, plugin version, IDE version, and attachments selected by the user."
+    "The report may contain stack traces, plugin version," +
+            " IDE version, and attachments selected by the user."
 
   override fun submit(
     events: Array<IdeaLoggingEvent>,
@@ -85,13 +89,15 @@ class MyErrorReportSubmitter : ErrorReportSubmitter() {
 ```
 
 Where:
+
 - `getReportActionText()` defines the text shown on the report button in the reporting UI
 - `getPrivacyNoticeText()` must explain to users what data is sent and how it is used
 - `submit()` performs the actual submission
 
 The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) data selected for the report:
-- events - `IdeaLoggingEvent` instances give access to the core report data, such as the throwable, message text, and attachments included in the report
-- `additionalInfo` - the free-form text entered by the user in the comment box as 
+
+- events - `IdeaLoggingEvent` instances give access to the core report data, such as the `Throwable`, message text, and attachments included in the report.
+- `additionalInfo` - the free-form text entered by the user in the comment box as
 - `parentComponent` - for any necessary interaction
 - `consumer` - callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java).
 This is the main integration point for building a custom payload for an issue tracker or backend service.
@@ -109,12 +115,10 @@ If submission cannot even start, `submit()` must return `false`.
 >
 {style="warning"}
 
-## Threading and Coroutines
+### Threading and Coroutines
 
-`ErrorReportSubmitter.submit()` is part of the error reporting UI flow.
-Like any code participating in UI handling, it should return quickly and avoid expensive blocking work on EDT.
-
-The general threading rules from [](threading_model.md) apply here as well.
+`ErrorReportSubmitter.submit()` should return quickly and avoid expensive blocking work as it runs on the EDT.
+Therefore, the general threading rules from [](threading_model.md) apply here as well.
 That means, operations on EDT must be as fast as possible to avoid UI freezes, while
 network, file, and other expensive operations belong on background threads.
 
@@ -130,7 +134,10 @@ Use [`Dispatchers.IO`](coroutine_dispatchers.md) for network and file I/O.
 class ReportingService(
   private val cs: CoroutineScope
 ) {
-  fun submitReport(report: ReportData, consumer: Consumer<in SubmittedReportInfo>) {
+  fun submitReport(
+      report: ReportData,
+      consumer: Consumer<in SubmittedReportInfo>)
+  {
     cs.launch {
       val result = withContext(Dispatchers.IO) {
         sendToBackend(report)
@@ -146,40 +153,15 @@ This pattern keeps the reporting UI responsive while still integrating cleanly w
 Also, do not perform long-running non-cancellable read actions while collecting data for a report.
 Long-running read actions on background threads can block write actions and cause UI freezes.
 If additional project or PSI data is needed for a report, keep access short and use the modern threading
-and coroutine APIs described in [](threading_model.md) and [](launching_coroutines.md).
-
-## Attachments and Freeze Reports
-
-An exception report is often centered around a throwable and its stack trace.
-However, you can provide additional context for such reports and log exceptions with attachments when useful:
-
-```kotlin
-try {
-  // some code
-}
-catch (e: Throwable) {
-  thisLogger().error("some code failed", e, Attachment("details.txt", "extra diagnostics"))
-}
-```
-
-Those attachments may later appear in the reporting UI and become part of the report delivered to the plugin's submitter.
-
-Freeze reports are different from ordinary exception reports because they describe a stalled UI and usually need more evidence to explain what the IDE was waiting for.
-Therefore, when the platform records a plugin-attributed UI freeze, the report may contain one or more thread dumps and additional attachments collected during freeze reporting.
-
-For `ErrorReportSubmitter`, those artifacts may appear as attachments in the `IdeaLoggingEvent`.
-For `ErrorReportSink`, they are represented explicitly by `UnhandledFreezeReport.attachments` and `UnhandledFreezeReport.threadDumps`.
-
-Freeze reports are often caused by lock contention, blocking I/O, or long-running work that prevents EDT from progressing.
-In these cases, a simple exception stack trace is not enough, and thread dumps plus freeze-specific attachments help answer what EDT was waiting for, which thread was holding the relevant lock, whether the plugin was doing background work that blocked a write action, and whether the stall was transient, repeated, or part of a larger problem.
-
-This is why freeze reports are usually much more diagnostically valuable than a plain stack trace.
+and coroutine APIs described in [](threading_model.md#accessing-data) and [](launching_coroutines.md).
 
 ## Automatic Reporting with `ErrorReportSink`
 
-[`ErrorReportSink`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt) is an experimental API for automatic background reporting.
+[`ErrorReportSink`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt)
+is an experimental API for automatic background reporting.
 
-Register it in <path>plugin.xml</path>:
+Register it via the <include from="snippets.topic" element-id="ep"><var name="ep" value="com.intellij.errorReportSink"/></include>
+in <path>plugin.xml</path>:
 
 ```xml
 <extensions defaultExtensionNs="com.intellij">
@@ -190,7 +172,6 @@ Register it in <path>plugin.xml</path>:
 Example:
 
 ```kotlin
-@Suppress("UnstableApiUsage")
 class MyErrorReportSink : ErrorReportSink {
   override suspend fun submit(report: UnhandledErrorReport) {
     when (report) {
@@ -209,12 +190,49 @@ class MyErrorReportSink : ErrorReportSink {
 - `UnhandledExceptionReport` contains the exception class and stack trace
 - `UnhandledFreezeReport` contains a message, the freeze duration, attachments, and thread dumps
 
-`ErrorReportSink` is intended for plugin observability, not guaranteed report delivery.
-Bundled IDE plugins are not notified about their errors, at most 10,000 exception reports per plugin per IDE session are forwarded,
-the platform does not deduplicate or debounce repeated exceptions, and exception reports contain less information than user-submitted reports.
+`ErrorReportSink` is intended for plugin observability, not guaranteed report delivery and at most 10,000 exception
+reports per plugin per IDE session are forwarded.
+Note, that the platform does not deduplicate or debounce repeated exceptions, and exception reports contain less information
+than user-submitted reports.
 
 The current platform implementation delivers sink reports asynchronously on a background dispatcher.
 Plugins should still keep sink processing short, deduplicate repeated failures, and rate-limit any backend traffic on their side.
+
+## Attachments and Freeze Reports
+
+An exception report is often centered around a `Throwable` and its stack trace.
+However, you can provide additional context for such reports and log exceptions with attachments when useful:
+
+```kotlin
+try {
+  // some code
+}
+catch (e: Throwable) {
+  thisLogger().error(
+      "some code failed",
+      e,
+      Attachment("details.txt", "extra diagnostics")
+  )
+}
+```
+
+Those attachments may later appear in the reporting UI and become part of the report delivered to the plugin's submitter.
+
+Freeze reports are different from ordinary exception reports because they describe a stalled UI and usually need more evidence to explain what the IDE was waiting for.
+Therefore, when the platform records a plugin-attributed UI freeze, the report may contain one or more thread dumps and additional attachments collected during freeze reporting.
+
+For `ErrorReportSubmitter`, those artifacts may appear as attachments in the `IdeaLoggingEvent`.
+For `ErrorReportSink`, they are represented explicitly by `UnhandledFreezeReport.attachments` and `UnhandledFreezeReport.threadDumps`.
+
+Freeze reports are often caused by lock contention, blocking I/O, or long-running work that prevents EDT from progressing.
+In these cases, a simple exception stack trace is not enough and thread dumps plus freeze-specific attachments help answer:
+
+- what EDT was waiting for
+- which thread was holding the relevant lock
+- whether the plugin was doing background work that blocked a write action
+- whether the stall was transient, repeated, or part of a larger problem.
+
+This is why freeze reports are usually much more diagnostically valuable than a plain stack trace.
 
 ## Choosing Between the APIs
 
@@ -226,17 +244,15 @@ Use `ErrorReportSubmitter` when:
 
 Use `ErrorReportSink` when:
 - the plugin should observe failures even if the user does nothing
-- the goal is telemetry, counting, alerting, or best-effort backend forwarding
+- the goal is telemetry, counting, alerting, or sending reports to your backend when possible, without guaranteeing delivery
 - automatic freeze visibility is important
 
 Use both APIs when the plugin needs background observability during normal usage and also a richer user-driven reporting path for manual submission.
 
-## See Also
+## Example Implementations
 
-- This excellent [tutorial](https://www.plugin-dev.com/intellij/general/error-reporting/) offers a working solution for using _Sentry_
-- [](ide_infrastructure.md)
-- [](plugin_user_experience.md)
-- [](threading_model.md)
-- [](kotlin_coroutines.md)
-- [](launching_coroutines.md)
-- [](coroutine_dispatchers.md)
+- [ITNReporter](%gh-ic%/platform/platform-impl/src/com/intellij/diagnostic/ITNReporter.kt)
+  A full production implementation that submits fatal error reports, shows progress and notifications, and completes the `SubmittedReportInfo` callback.
+- [`UnhandledReportSinkServiceTest.TestSink`](%gh-ic%/platform/platform-tests/testSrc/com/intellij/diagnostic/UnhandledReportSinkServiceTest.kt)
+  A tiny sink used in tests that simply receives an UnhandledErrorReport in submit(report) and stores it for verification.
+- [Third party tutorial](https://www.plugin-dev.com/intellij/general/error-reporting/) for error reporting using _Sentry_

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -1,0 +1,228 @@
+<!-- Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+# Error Reporting
+
+<web-summary>
+How to let users report plugin errors from the IDE, how to receive automatic error reports in the background, and how to handle freeze reports safely.
+</web-summary>
+
+<link-summary>User-facing and automatic reporting APIs for plugin-attributed exceptions and freezes.</link-summary>
+
+The IntelliJ Platform can detect many errors caused by plugin code and attribute them to the responsible plugin.
+Plugin authors can integrate with that flow in two different ways:
+
+- [`ErrorReportSubmitter`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSubmitter.java) handles the user-facing reporting flow from the IDE Fatal Errors UI.
+- [`ErrorReportSink`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt) receives automatic background reports about unhandled exceptions and UI freezes attributed to the plugin.
+
+These APIs complement each other.
+`ErrorReportSubmitter` is the user-facing reporting API.
+It is triggered when the user chooses to submit a report from the IDE UI, so the user is explicitly involved in the process.
+It is typically used for issue tracker integration, custom backend submission, privacy notices, and account-aware reporting.
+The submitter receives `IdeaLoggingEvent` instances together with the user comment, any included attachments,
+and a callback used to complete the submission flow.
+
+`ErrorReportSink` is the automatic background reporting API.
+It is triggered when the platform automatically forwards a plugin-attributed exception or freeze, so no user action is required.
+It is typically used for telemetry, counters, deduplication, and best-effort backend forwarding.
+The sink receives either [`UnhandledExceptionReport`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt)
+or [`UnhandledFreezeReport`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt),
+which makes it suitable for observability scenarios even when the user never clicks a reporting action.
+
+<video src="https://www.youtube.com/watch?v=F4ZQe3AU3v4" title="How We Built Comma, the Raku IDE, on the IntelliJ Platform"/>
+
+## The Easy Way: JetBrains Marketplace Exception Analyzer
+
+If the plugin is published on JetBrains Marketplace and the built-in reporting flow is sufficient, this is the simplest supported setup.
+
+Register the Marketplace submitter in <path>plugin.xml</path>:
+
+```xml
+<extensions defaultExtensionNs="com.intellij">
+  <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>
+</extensions>
+```
+
+This approach requires no custom `ErrorReportSubmitter` implementation in the plugin.
+The IDE uses the built-in submitter to send reports to the backend provided by JetBrains.
+
+See [JetBrains Exception Analyzer](https://plugins.jetbrains.com/docs/marketplace/exception-analyzer.html)
+for setup details and current product-specific behavior.
+
+## Custom Implementation of `ErrorReportSubmitter`
+
+Use a custom submitter when the plugin needs control over the backend, payload, privacy notice, or the post-submission workflow.
+
+Register the submitter in <path>plugin.xml</path>:
+
+```xml
+<extensions defaultExtensionNs="com.intellij">
+  <errorHandler implementation="my.plugin.MyErrorReportSubmitter"/>
+</extensions>
+```
+
+The public contract is defined by [`ErrorReportSubmitter`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSubmitter.java).
+Reports are delivered as [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) instances,
+and the final result is reported back to the IDE using
+[`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java).
+
+```kotlin
+class MyErrorReportSubmitter : ErrorReportSubmitter() {
+  override fun getReportActionText(): String = "Report to Vendor"
+
+  override fun getPrivacyNoticeText(): String =
+    "The report may contain stack traces, plugin version, IDE version, and attachments selected by the user."
+
+  override fun submit(
+    events: Array<IdeaLoggingEvent>,
+    additionalInfo: String?,
+    parentComponent: Component,
+    consumer: Consumer<in SubmittedReportInfo>
+  ): Boolean {
+    // Start background work, then complete consumer later.
+    return true
+  }
+}
+```
+
+Here, `getReportActionText()` defines the text shown on the report button in the reporting UI,
+`getPrivacyNoticeText()` must explain to users what data is sent and how it is used, and `submit()` performs the actual submission.
+
+The `submit()` method receives the [`IdeaLoggingEvent`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/IdeaLoggingEvent.java) data selected for the report, the free-form text entered by the user in the comment box as `additionalInfo`, a `parentComponent` for any necessary interaction, and a `consumer` callback that must receive the final [`SubmittedReportInfo`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/SubmittedReportInfo.java). An `IdeaLoggingEvent` gives access to the core report data, such as the throwable, message text, and attachments included in the report.
+This is the main integration point for building a custom payload for an issue tracker or backend service.
+
+If `submit()` returns `true`, the submitter is declaring that submission has started and the callback will be completed later.
+The callback must eventually receive a `SubmittedReportInfo` stating if a `NEW_ISSUE` has been filed, the report was a
+`DUPLICATE`, or if the submission has `FAILED` altogether.
+
+If submission cannot even start, you must return `false` from `submit()`.
+
+> Do not leave the callback unfinished after returning `true`.
+> The IDE uses that callback to update the reporting UI and final submission state.
+>
+{style="warning"}
+
+## Threading and Coroutines
+
+`ErrorReportSubmitter.submit()` is part of the error reporting UI flow.
+Like any code participating in UI handling, it should return quickly and avoid expensive blocking work on EDT.
+
+The general threading rules from [](threading_model.md) apply here as well.
+That means, operations on EDT must be as fast as possible to avoid UI freezes, while
+network, file, and other expensive operations belong on background threads.
+
+For plugins targeting 2024.1+, [Kotlin coroutines](kotlin_coroutines.md) are the recommended approach for asynchronous work.
+
+To keep `submit()` lightweight, a typical implementation first extracts the information needed from the incoming events, then starts the expensive work in the background, returns `true`, and finally completes the callback when submission finishes.
+
+When using coroutines, prefer a [service scope](launching_coroutines.md#launching-coroutine-from-service-scope) for submission work.
+Use [`Dispatchers.IO`](coroutine_dispatchers.md) for network and file I/O.
+
+```kotlin
+@Service
+class ReportingService(
+  private val cs: CoroutineScope
+) {
+  fun submitReport(report: ReportData, consumer: Consumer<in SubmittedReportInfo>) {
+    cs.launch {
+      val result = withContext(Dispatchers.IO) {
+        sendToBackend(report)
+      }
+      consumer.consume(result)
+    }
+  }
+}
+```
+
+This pattern keeps the reporting UI responsive while still integrating cleanly with the IDE callback contract.
+
+Also, do not perform long-running non-cancellable read actions while collecting data for a report.
+Long-running read actions on background threads can block write actions and cause UI freezes.
+If additional project or PSI data is needed for a report, keep access short and use the modern threading
+and coroutine APIs described in [](threading_model.md) and [](launching_coroutines.md).
+
+## Attachments and Freeze Reports
+
+An exception report is often centered around a throwable and its stack trace.
+However, you can provide additional context for such reports and log exceptions with attachments when useful:
+
+```kotlin
+try {
+  // some code
+}
+catch (e: Throwable) {
+  thisLogger().error("some code failed", e, Attachment("details.txt", "extra diagnostics"))
+}
+```
+
+Those attachments may later appear in the reporting UI and become part of the report delivered to the plugin's submitter.
+
+Freeze reports are different from ordinary exception reports because they describe a stalled UI and usually need more evidence to explain what the IDE was waiting for.
+Therefore, when the platform records a plugin-attributed UI freeze, the report may contain one or more thread dumps and additional attachments collected during freeze reporting.
+
+For `ErrorReportSubmitter`, those artifacts may appear as attachments in the `IdeaLoggingEvent`.
+For `ErrorReportSink`, they are represented explicitly by `UnhandledFreezeReport.attachments` and `UnhandledFreezeReport.threadDumps`.
+
+Freeze reports are often caused by lock contention, blocking I/O, or long-running work that prevents EDT from progressing.
+In these cases, a simple exception stack trace is not enough, and thread dumps plus freeze-specific attachments help answer what EDT was waiting for, which thread was holding the relevant lock, whether the plugin was doing background work that blocked a write action, and whether the stall was transient, repeated, or part of a larger problem.
+
+This is why freeze reports are usually much more diagnostically valuable than a plain stack trace.
+
+## Automatic Reporting with `ErrorReportSink`
+
+[`ErrorReportSink`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt) is an experimental API for automatic background reporting.
+
+Register it in <path>plugin.xml</path>:
+
+```xml
+<extensions defaultExtensionNs="com.intellij">
+  <errorReportSink implementation="my.plugin.MyErrorReportSink"/>
+</extensions>
+```
+
+Example:
+
+```kotlin
+@Suppress("UnstableApiUsage")
+class MyErrorReportSink : ErrorReportSink {
+  override suspend fun submit(report: UnhandledErrorReport) {
+    when (report) {
+      is UnhandledExceptionReport -> {
+        // collect metrics or forward to backend
+      }
+      is UnhandledFreezeReport -> {
+        // inspect duration, attachments, and thread dumps
+      }
+    }
+  }
+}
+```
+
+`ErrorReportSink` currently delivers two report types. `UnhandledExceptionReport` contains the exception class and stack trace.
+`UnhandledFreezeReport` contains a message, the freeze duration, attachments, and thread dumps.
+
+`ErrorReportSink` is intended for plugin observability, not guaranteed report delivery.
+Bundled IDE plugins are not notified about their errors, at most 10,000 exception reports per plugin per IDE session are forwarded,
+the platform does not deduplicate or debounce repeated exceptions, and exception reports contain less information than user-submitted reports.
+
+The current platform implementation delivers sink reports asynchronously on a background dispatcher.
+Plugins should still keep sink processing short, deduplicate repeated failures, and rate-limit any backend traffic on their side.
+
+## Choosing Between the APIs
+
+Use `ErrorReportSubmitter` when the user should explicitly submit the report, when the plugin needs the user comment,
+when a custom privacy notice or account-aware reporting is required, or when the backend expects a richer user-facing reporting flow.
+
+Use `ErrorReportSink` when the plugin should observe failures even if the user does nothing, when the goal is telemetry,
+counting, alerting, or best-effort backend forwarding, or when automatic freeze visibility is important.
+
+Use both APIs when the plugin needs background observability during normal usage and also a richer user-driven reporting path for manual submission.
+
+## See Also
+
+- This excellent [tutorial](https://www.plugin-dev.com/intellij/general/error-reporting/) offers a working solution for using _Sentry_
+- [](ide_infrastructure.md)
+- [](plugin_user_experience.md)
+- [](threading_model.md)
+- [](kotlin_coroutines.md)
+- [](launching_coroutines.md)
+- [](coroutine_dispatchers.md)

--- a/topics/basics/error_reporting.md
+++ b/topics/basics/error_reporting.md
@@ -218,8 +218,11 @@ Plugins should still keep sink processing short, deduplicate repeated failures, 
 
 ## Choosing Between the APIs
 
-Use `ErrorReportSubmitter` when the user should explicitly submit the report, when the plugin needs the user comment,
-when a custom privacy notice or account-aware reporting is required, or when the backend expects a richer user-facing reporting flow.
+Use `ErrorReportSubmitter` when:
+- the user should explicitly submit the report
+- the plugin needs the user comment
+- a custom privacy notice or account-aware reporting is required
+- the backend expects a richer user-facing reporting flow
 
 Use `ErrorReportSink` when:
 - the plugin should observe failures even if the user does nothing

--- a/topics/basics/ide_infrastructure.md
+++ b/topics/basics/ide_infrastructure.md
@@ -83,11 +83,15 @@ The IDE will show fatal errors caught by itself as well as logging messages with
 
 For the latter, reporting is disabled by default — instead, there's an option to disable the plugin causing the exception.
 
-To let users report such errors to the vendor, plugins can use one of the solutions:
+To let plugins report errors, you can use the following supported solutions:
+
 - Use [JetBrains Exception Analyzer (EA)](https://plugins.jetbrains.com/docs/marketplace/exception-analyzer.html) that sends errors to the backend provided by JetBrains (2023.3+).
 - Implement custom [`ErrorReportSubmitter`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSubmitter.java) registered in <include from="snippets.topic" element-id="ep"><var name="ep" value="com.intellij.errorHandler"/></include>.
-Existing implementations range from pre-filling web-based issue tracker forms to fully automated submission to log monitoring systems.
-This [tutorial](https://www.plugin-dev.com/intellij/general/error-reporting/) also offers a working solution for using _Sentry_.
+- For automatic background observability, plugins can also implement experimental [`ErrorReportSink`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSink.kt) registered in <include from="snippets.topic" element-id="ep"><var name="ep" value="com.intellij.errorReportSink"/></include>.
+
+For the complete setup and API details, see [](error_reporting.md).
+That page explains when to use `ErrorReportSubmitter` or `ErrorReportSink`,
+how to submit reports without freezing the UI, and why freeze-specific attachments matter.
 
 The red exclamation notification icon in the status bar is controlled with the `idea.fatal.error.notification` system property.
 The property can be edited in <path>idea.properties</path> file opened with <ui-path>Help | Edit Custom Properties...</ui-path>:

--- a/topics/basics/ide_infrastructure.md
+++ b/topics/basics/ide_infrastructure.md
@@ -83,7 +83,7 @@ The IDE will show fatal errors caught by itself as well as logging messages with
 
 For the latter, reporting is disabled by default — instead, there's an option to disable the plugin causing the exception.
 
-To let plugins report errors, you can use the following supported solutions:
+To let plugins report errors, the following solutions are available:
 
 - Use [JetBrains Exception Analyzer (EA)](https://plugins.jetbrains.com/docs/marketplace/exception-analyzer.html) that sends errors to the backend provided by JetBrains (2023.3+).
 - Implement custom [`ErrorReportSubmitter`](%gh-ic%/platform/platform-api/src/com/intellij/openapi/diagnostic/ErrorReportSubmitter.java) registered in <include from="snippets.topic" element-id="ep"><var name="ep" value="com.intellij.errorHandler"/></include>.

--- a/topics/intro/content_updates.md
+++ b/topics/intro/content_updates.md
@@ -12,6 +12,12 @@ See [GitHub Changelog](https://github.com/JetBrains/intellij-sdk-docs/commits/ma
 
 ## 2026
 
+### July
+{#july-26}
+
+Error Reporting
+: Add a new page with details about [](error_reporting.md).
+
 ### March
 {#march-26}
 


### PR DESCRIPTION
* Introduce a new `error_reporting.md` topic covering error reporting APIs (`ErrorReportSubmitter` and `ErrorReportSink`) for plugins.
* Update `ide_infrastructure.md` to reference the new topic.
* Extend the table of contents to include the error reporting documentation under "IDE Infrastructure".