### PR TITLE
Refactor plugin installation to use newer installPluginFromDir

### DIFF
--- a/topics/basics/testing_plugins/integration_tests/integration_tests_intro.md
+++ b/topics/basics/testing_plugins/integration_tests/integration_tests_intro.md
@@ -133,7 +133,7 @@ The test case uses IntelliJ IDEA version 2024.3, and starts the IDE without any 
 ```kotlin
 .apply {
   val pathToPlugin = System.getProperty("path.to.build.plugin")
-  PluginConfigurator(this).installPluginFromFolder(File(pathToPlugin))
+  PluginConfigurator(this).installPluginFromDir(Path.of(pathToPlugin))
 }
 ```
 
@@ -225,7 +225,7 @@ fun simpleTest() {
     ).withVersion("2024.2")
   ).apply {
     val pathToPlugin = System.getProperty("path.to.build.plugin")
-    PluginConfigurator(this).installPluginFromFolder(File(pathToPlugin))
+    PluginConfigurator(this).installPluginFromDir(Path.of(pathToPlugin))
   }.runIdeWithDriver().useDriverAndCloseIde {
     waitForIndicators(5.minutes)
   }
@@ -318,7 +318,7 @@ class PluginTest {
       ).withVersion("2024.2")
     ).apply {
       val pathToPlugin = System.getProperty("path.to.build.plugin")
-      PluginConfigurator(this).installPluginFromFolder(File(pathToPlugin))
+      PluginConfigurator(this).installPluginFromDir(Path.of(pathToPlugin))
     }.runIdeWithDriver().useDriverAndCloseIde {
       waitForIndicators(5.minutes)
     }


### PR DESCRIPTION
First example already uses the newer installPluginFromDir method. Examples better be consistent I think.

If the bridge to the older method is needed it could be written as a note, like zinstallPluginFromFolder is the deprecated way to do this, use installPluginFromDir nowz, but I think it's too much given IDE has the warning already