### PR TITLE
Document deprecation of CLion Classic engine APIs

### DIFF
--- a/reference_guide/api_changes_list_2026.md
+++ b/reference_guide/api_changes_list_2026.md
@@ -301,6 +301,25 @@ The migration should be done according to the [migration guide](https://kotlin.g
 `org.jetbrains.kotlin.js.descriptorUtils.DescriptorUtilsKt.getNameIfStandardType(KotlinType)` method removed
 : [Migrate to K2 (Analysis API)](https://kotlin.github.io/analysis-api/migrating-from-k1.html).
 
+### CLion 2026.2
+
+The C/C++ language engine based on `com.intellij.cidr.lang` (CLion Classic) is no longer bundled with CLion.
+CLion Nova, based on the ReSharper C++ engine, is now the default and the only bundled C/C++ engine.
+The classic APIs remain available via the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin (ID `com.intellij.cidr.lang`).
+Plugins depending on these APIs must declare a dependency on the Marketplace plugin using [`plugin("com.intellij.cidr.lang", "<version>")`](tools_intellij_platform_gradle_plugin_dependencies_extension.md#non-bundled-plugin).
+See [C/C++ Language Engine: Nova and Classic](clion.md#language-engine) for setup details and CLion Nova API replacements.
+
+`com.jetbrains.cidr.lang.OCFileType` class removed
+: The Classic C/C++ engine is no longer bundled. Depend on the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin to keep using it, or migrate to `com.jetbrains.rider.cpp.fileType.CppFileType` (CLion Nova).
+
+`com.jetbrains.cidr.lang.OCLanguage` class removed
+: The Classic C/C++ engine is no longer bundled. Depend on the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin to keep using it, or migrate to `com.jetbrains.rider.cpp.fileType.CppLanguage` (CLion Nova).
+
+`com.jetbrains.cidr.lang.psi.OCFile` class removed
+: Depend on the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin to keep using it, or use `com.jetbrains.rider.cpp.fileType.psi.CppFile` (CLion Nova) for file-level access only.
+
+CLion Nova has no frontend PSI, so the remaining `com.jetbrains.cidr.lang` classes — PSI, symbols, types, and resolve/references — have no replacement; depend on the Classic Engine plugin to keep using them.
+
 ## 2026.3
 
 ### IntelliJ Platform 2026.3

--- a/topics/products/clion/clion.md
+++ b/topics/products/clion/clion.md
@@ -100,12 +100,6 @@ The classic C/C++ language support — including `OCFileType`, `OCLanguage`, `OC
 As this plugin is no longer bundled, declare a dependency on its Marketplace version using the [`plugin()`](tools_intellij_platform_gradle_plugin_dependencies_extension.md#non-bundled-plugin) function:
 
 ```kotlin
-repositories {
-  mavenCentral()
-  intellijPlatform {
-    defaultRepositories()
-  }
-}
 
 dependencies {
   intellijPlatform {

--- a/topics/products/clion/clion.md
+++ b/topics/products/clion/clion.md
@@ -13,6 +13,12 @@ Plugin projects for CLion can be developed using [IntelliJ IDEA](idea.md).
 
 > CLion is free for non-commercial use
 
+> Since CLion 2025.3, CLion Nova — the C/C++ language engine based on the ReSharper C++ engine — is enabled by default.
+> Since CLion 2026.2, the previous _Classic_ engine is no longer bundled with the IDE distribution.
+> If your plugin uses the classic C/C++ language APIs (`OCFileType`, `OCLanguage`, `OCFile`, and other `com.jetbrains.cidr.lang` classes), see [C/C++ Language Engine: Nova and Classic](#language-engine) for the required changes.
+>
+{style="warning"}
+
 ## CLion Plugin Setup
 
 ### Gradle Build Script
@@ -72,6 +78,80 @@ Click on an entry in the table's *Attribute* column to go to the documentation a
 The dependency on the CLion APIs must be declared in the <path>[plugin.xml](plugin_configuration_file.md)</path> file.
 As described in [Modules Specific to Functionality](plugin_compatibility.md#modules-specific-to-functionality) table, the [`<depends>`](plugin_configuration_file.md#idea-plugin__depends) tags must declare `com.intellij.modules.clion` module dependency,
 or `com.intellij.clion` plugin dependency when targeting only versions 2020.3+.
+
+## C/C++ Language Engine: Nova and Classic {id="language-engine"}
+
+CLion provides two C/C++ language engines:
+
+* **Nova** – the current engine based on the ReSharper C++ engine.
+  It is enabled by default since CLion 2025.3 and is the only engine bundled with the IDE since CLion 2026.2.
+* **Classic** – the original in-IDE engine, backed by the `com.intellij.cidr.lang` plugin and the `com.jetbrains.cidr.lang` APIs.
+  Since CLion 2026.2, it is no longer bundled and is distributed only as a separate JetBrains Marketplace plugin.
+
+> The Classic engine plugin is provided as a temporary compatibility measure for existing plugins and will be removed in a future release.
+> Migrate to the Nova APIs where possible.
+>
+{style="warning"}
+
+### Using the Classic C/C++ Language APIs
+
+The classic C/C++ language support — including `OCFileType`, `OCLanguage`, `OCFile`, and the rest of the `com.jetbrains.cidr.lang` package — is available in the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin (ID `com.intellij.cidr.lang`).
+
+As this plugin is no longer bundled, declare a dependency on its Marketplace version using the [`plugin()`](tools_intellij_platform_gradle_plugin_dependencies_extension.md#non-bundled-plugin) function:
+
+```kotlin
+repositories {
+  mavenCentral()
+  intellijPlatform {
+    defaultRepositories()
+  }
+}
+
+dependencies {
+  intellijPlatform {
+    clion("<versionNumber>")
+    bundledPlugin("com.intellij.clion")
+
+    // C/C++ Language Support via Classic Engine (unbundled since 2026.2)
+    plugin("com.intellij.cidr.lang", "<pluginVersion>")
+  }
+}
+```
+
+> The [`compatiblePlugin()`](tools_intellij_platform_gradle_plugin_dependencies_extension.md#compatible-plugins) helper can be used instead to resolve a version compatible with the targeted CLion automatically.
+>
+{style="tip"}
+
+The `com.intellij.modules.cidr.lang` module dependency in the <path>[plugin.xml](plugin_configuration_file.md)</path> file stays unchanged:
+
+```xml
+<depends>com.intellij.modules.cidr.lang</depends>
+```
+
+### Migrating to Nova
+
+Nova represents C/C++ files with different classes located in the `com.jetbrains.rider.cpp.fileType` package:
+
+| Classic (`com.jetbrains.cidr.lang`) | Nova (`com.jetbrains.rider.cpp.fileType`) |
+|-------------------------------------|-------------------------------------------|
+| `OCFileType`                        | `CppFileType`                             |
+| `OCLanguage`                        | `CppLanguage`                             |
+| `psi.OCFile`                        | `psi.CppFile`                             |
+
+Nova performs C/C++ code analysis in a separate backend process and does not expose a frontend PSI model.
+Apart from the file type and language above (and basic traversal via `com.jetbrains.rider.cpp.fileType.psi.CppElement`), there is no replacement for the Classic frontend APIs, including:
+
+* PSI elements — `com.jetbrains.cidr.lang.psi.OCFile`, `com.jetbrains.cidr.lang.psi.OCIncludeDirective`, `com.jetbrains.cidr.lang.psi.OCPragma`, and the rest of the `com.jetbrains.cidr.lang.psi` package
+* symbols — the `com.jetbrains.cidr.lang.symbols` package
+* types — `com.jetbrains.cidr.lang.types.OCType`
+* resolve and references — the `com.jetbrains.cidr.lang.resolve` package
+
+> Plugins relying on these APIs cannot be fully ported to Nova.
+> Keep depending on the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) plugin if these APIs are required.
+>
+{style="note"}
+
+If your plugin cannot be migrated to CLion Nova yet, follow and vote for [CPP-36085](https://youtrack.jetbrains.com/issue/CPP-36085) to track improvements to Classic-to-Nova plugin migration.
 
 ## Available CLion APIs
 


### PR DESCRIPTION
Documents the CLion Classic → Nova API change: since CLion 2026.2 the Classic C/C++ engine (`com.intellij.cidr.lang`, `OCFileType`/`OCLanguage`/`OCFile`, …) is no longer bundled and ships only as the [C/C++ Language Support via Classic Engine](https://plugins.jetbrains.com/plugin/32355-c-c--language-support-via-classic-engine) Marketplace plugin.

Changes:
- `reference_guide/api_changes_list_2026.md` — adds a **CLion 2026.2** section to the breaking-changes list with `class removed` entries and API-replacement suggestions.
- `topics/products/clion/clion.md` — adds a top-level notice and a **C/C++ Language Engine: Nova and Classic** section covering the Marketplace-plugin dependency (`compatiblePlugin`), the OC* → Cpp* mapping, and the no-frontend-PSI limitation.

Requested via IJSDK-2756; tracked by CPP-51126. Plugin authors are pointed to CPP-36085 to follow migration progress.