### PR TITLE
Fix remote topic event sender method name

### DIFF
--- a/topics/basics/remote_development/remote_procedure_calls.md
+++ b/topics/basics/remote_development/remote_procedure_calls.md
@@ -389,7 +389,7 @@ class BackendChatRepositoryModel {
     val userMessage = chatMessageFactory.createUserMessage(messageContent)
     _messages.value += userMessage
 
-    NEW_MESSAGE_TOPIC.send(
+    NEW_MESSAGE_TOPIC.broadcast(
        NewMessageEvent(project.projectId(), userMessage.id)
     )
   }


### PR DESCRIPTION
Both `ApplicationRemoteTopic` and `ProjectRemoteTopic` use a function named `broadcast()` instead of `send()`.